### PR TITLE
fix: [#31,#32] Options cleanup

### DIFF
--- a/modules/au.com.trgtd.tr.appl/src/au/com/trgtd/tr/appl/layer.xml
+++ b/modules/au.com.trgtd.tr.appl/src/au/com/trgtd/tr/appl/layer.xml
@@ -234,6 +234,7 @@
             <file name="org-netbeans-core-ui-options-filetypes-FileAssociationsOptionsPanelController.instance_hidden"/>
             <file name="org-netbeans-core-windows-options-WinSysAdvancedOption.instance_hidden"/>
             <file name="org-netbeans-core-windows-options-WinSysOptionsPanelController.instance_hidden"/>
+            <file name="org-netbeans-janitor-JanitorSettings.instance_hidden"/>
             <file name="org-netbeans-modules-bugtracking-util-BugtrackingOptions.instance_hidden"/>
             <file name="org-netbeans-modules-javascript-editing-options-JsOptionsController.instance_hidden"/>
             <file name="org-netbeans-modules-spellchecker-options-SpellcheckerOptionsPanelController.instance_hidden"/>

--- a/modules/au.com.trgtd.tr.appl/src/au/com/trgtd/tr/appl/layer.xml
+++ b/modules/au.com.trgtd.tr.appl/src/au/com/trgtd/tr/appl/layer.xml
@@ -240,6 +240,9 @@
             <file name="org-netbeans-modules-spellchecker-options-SpellcheckerOptionsPanelController.instance_hidden"/>
             <file name="org-netbeans-modules-versioning-util-VcsAdvancedOptions.instance_hidden"/>
         </folder>
+        <file name="Editor.instance_hidden"/>
+        <file name="FontsAndColors.instance_hidden"/>
+        <file name="Team.instance_hidden"/>
     </folder>
 
     <file name="QuickSearch_hidden"/>


### PR DESCRIPTION
Fixes #31 
Fixes #32

- hides Options 'Edit', 'Fonts & Colors', 'Teams'.
- hides advanced options 'Janitor'.