### PR TITLE
fix: [#57] Remove cluster `ide` and some modules

### DIFF
--- a/modules/au.com.trgtd.tr.extract/test/unit/src/au/com/trgtd/tr/extract/FormatTypeXmlEscapeTest.java
+++ b/modules/au.com.trgtd.tr.extract/test/unit/src/au/com/trgtd/tr/extract/FormatTypeXmlEscapeTest.java
@@ -32,7 +32,7 @@ public class FormatTypeXmlEscapeTest {
 
     @Test
     public void escapingBlank_returnsBlank() {
-        assertEquals("", xml.escape(""));
+        assertEquals("", xml.escape("BOOM"));
     }
 
     @Test

--- a/modules/au.com.trgtd.tr.extract/test/unit/src/au/com/trgtd/tr/extract/FormatTypeXmlEscapeTest.java
+++ b/modules/au.com.trgtd.tr.extract/test/unit/src/au/com/trgtd/tr/extract/FormatTypeXmlEscapeTest.java
@@ -32,7 +32,7 @@ public class FormatTypeXmlEscapeTest {
 
     @Test
     public void escapingBlank_returnsBlank() {
-        assertEquals("", xml.escape("BOOM"));
+        assertEquals("", xml.escape(""));
     }
 
     @Test

--- a/nbproject/platform.properties
+++ b/nbproject/platform.properties
@@ -13,7 +13,10 @@ cluster.path=\
     ${nbplatform.active.dir}/harness:\
     ${nbplatform.active.dir}/platform
 
-disabled.modules=
+disabled.modules=\
+    org.netbeans.libs.batik.read,\
+    org.netbeans.libs.junit4,\
+    org.netbeans.libs.junit5
     com.googlecode.javaewah.JavaEWAH,\
     com.jcraft.jsch,\
     com.jcraft.jzlib,\

--- a/nbproject/platform.properties
+++ b/nbproject/platform.properties
@@ -10,7 +10,6 @@ bootstrap.url=https://netbeans-vm1.apache.org/uc/${netbeans-plat-version}/tasks.
 autoupdate.catalog.url=https://netbeans-vm1.apache.org/uc/${netbeans-plat-version}/updates.xml.gz
 
 cluster.path=\
-    ${nbplatform.active.dir}/ide:\
     ${nbplatform.active.dir}/harness:\
     ${nbplatform.active.dir}/platform
 


### PR DESCRIPTION
(Almost) fixes #57

It looks like most of the unexpected modules in the plugin-manager of the current development version disappear after removing cluster `ide`. In addition I inactivated a few additional modules.

I haven't found functionality yet that stops working after removing that.

The list of modules still shown in the plugin manager does not exactly match the one in 3.7.0 but it is very close. IMHO good enought to close this issue. We can always create additional PRs to remove more modules if we found out how to do that.