### PR TITLE
fix(perf): [#76] Properly set cachedir to speed up (subsequent) launches of the application

### DIFF
--- a/nbproject/trgtd.conf
+++ b/nbproject/trgtd.conf
@@ -1,3 +1,4 @@
 default_userdir="${HOME}/.thinkingrock/tr-4.0"
+default_cachedir="${DEFAULT_CACHEDIR_ROOT}/tr-4.0"
 
 default_options="--locale en:UK --branding trgtd -J-client -J-Xss4m -J-Xms64m -J-Dsun.java2d.noddraw=true -J-Dsun.java2d.dpiaware=true -J-Dsun.zip.disableMemoryMapping=true -J--add-opens=java.base/java.security=ALL-UNNAMED -J--add-opens=java.base/java.lang=ALL-UNNAMED -J--add-opens=java.desktop/javax.swing=ALL-UNNAMED -J--add-opens=java.desktop/sun.awt=ALL-UNNAMED -J--add-opens=java.desktop/java.awt.font=ALL-UNNAMED -J--add-opens=java.base/java.text=ALL-UNNAMED -J--add-opens=java.base/java.lang.reflect=ALL-UNNAMED -J--add-opens=java.base/java.util=ALL-UNNAMED -J--add-opens=java.base/java.net=ALL-UNNAMED"

--- a/nbproject/trgtd.conf
+++ b/nbproject/trgtd.conf
@@ -1,4 +1,4 @@
-default_userdir="${HOME}/.thinkingrock/tr-4.0"
+default_userdir="${DEFAULT_USERDIR_ROOT}/tr-4.0"
 default_cachedir="${DEFAULT_CACHEDIR_ROOT}/tr-4.0"
 
 default_options="--locale en:UK --branding trgtd -J-client -J-Xss4m -J-Xms64m -J-Dsun.java2d.noddraw=true -J-Dsun.java2d.dpiaware=true -J-Dsun.zip.disableMemoryMapping=true -J--add-opens=java.base/java.security=ALL-UNNAMED -J--add-opens=java.base/java.lang=ALL-UNNAMED -J--add-opens=java.desktop/javax.swing=ALL-UNNAMED -J--add-opens=java.desktop/sun.awt=ALL-UNNAMED -J--add-opens=java.desktop/java.awt.font=ALL-UNNAMED -J--add-opens=java.base/java.text=ALL-UNNAMED -J--add-opens=java.base/java.lang.reflect=ALL-UNNAMED -J--add-opens=java.base/java.util=ALL-UNNAMED -J--add-opens=java.base/java.net=ALL-UNNAMED"


### PR DESCRIPTION
Resolves #76.

Sets the `default_cachedir` based on `DEFAULT_CACHEDIR_ROOT` set by the startup script, effectively using:

 - on Mac: "${HOME}/Library/Caches/trgtd/tr-4.0"
 - on Linux: "${HOME}/.cache/trgtd/tr-4.0"

With the cachedir set and the application launched once, subsequent launches will profit from the caching and will be much faster.

Also setting the `default_userdir` based on `DEFAULT_USERDIR_ROOT`, effectively using:

- on Mac: "${HOME}/Library/Application Support/trgtd/tr-4.0"
- on Linux: "${HOME}/.trgtd/tr-4.0"

Note that with previous versions of this 4.0.0-beta series, the user directory for both Mac and Linux was set to "${HOME}/.thinkingrock/tr-4.0", which is obsolete with this PR.

This second part is not performance related, but aligns the usage of setting both directories.

Not sure where the Windows equivalents will be.