### PR TITLE
refactor: Deprecated relative path in ....iconResource (cf. #20072)

### DIFF
--- a/modules/au.com.trgtd.tr.view.collect/src/au/com/trgtd/tr/view/collect/screen/ProcessToReferenceAction.java
+++ b/modules/au.com.trgtd.tr.view.collect/src/au/com/trgtd/tr/view/collect/screen/ProcessToReferenceAction.java
@@ -36,7 +36,7 @@ public class ProcessToReferenceAction extends CookieAction {
 
     @Override
     protected String iconResource() {
-        return "ProcessToReference.png";
+        return "au/com/trgtd/tr/view/collect/screen/ProcessToReference.png";
     }
     
     @Override

--- a/modules/au.com.trgtd.tr.view.collect/src/au/com/trgtd/tr/view/collect/screen/ProcessToSomedayAction.java
+++ b/modules/au.com.trgtd.tr.view.collect/src/au/com/trgtd/tr/view/collect/screen/ProcessToSomedayAction.java
@@ -36,7 +36,7 @@ public class ProcessToSomedayAction extends CookieAction {
 
     @Override
     protected String iconResource() {
-        return "ProcessToSomeday.png";
+        return "au/com/trgtd/tr/view/collect/screen/ProcessToSomeday.png";
     }
     
     @Override


### PR DESCRIPTION
Resolves warnings about deprecated relative paths in [...] .iconResource

<details><summary>Resolved warnings found in log file</summary>
<pre>
WARNING [org.openide.util.actions.SystemAction]: Deprecated relative path in au.com.trgtd.tr.view.collect.screen.ProcessToReferenceAction.iconResource (cf. #20072)
WARNING [org.openide.util.actions.SystemAction]: Deprecated relative path in au.com.trgtd.tr.view.collect.screen.ProcessToSomedayAction.iconResource (cf. #20072)
</pre>
</details>