### PR TITLE
refactor: use string templates for logging messages

### DIFF
--- a/modules/au.com.trgtd.tr.archive/src/au/com/trgtd/tr/archive/ArchiveAction.java
+++ b/modules/au.com.trgtd.tr.archive/src/au/com/trgtd/tr/archive/ArchiveAction.java
@@ -54,6 +54,7 @@ import tr.model.thought.Thought;
 import tr.model.util.Manager;
 import au.com.trgtd.tr.util.DateUtils;
 import au.com.trgtd.tr.util.UtilsFile;
+import java.util.logging.Level;
 
 /**
  * Archive action.
@@ -154,7 +155,7 @@ public final class ArchiveAction extends CallableSystemAction implements LookupL
         try {
             UtilsFile.copyFile(dataFile, backupFile);
         } catch (Exception ex) {
-            LOG.severe("Error creating archive backup of datafile. " + ex.getMessage()); // No I18N
+            LOG.log(Level.SEVERE, "Error creating archive backup of datafile. {0}", ex.getMessage()); // No I18N
             StatusDisplayer.getDefault().setStatusText("");
             return;
         }
@@ -166,7 +167,7 @@ public final class ArchiveAction extends CallableSystemAction implements LookupL
         try {
             UtilsFile.copyFile(dataFile, archiveFile);
         } catch (Exception ex) {
-            LOG.severe("Error creating archive copy of datafile. " + ex.getMessage()); // No I18N
+            LOG.log(Level.SEVERE, "Error creating archive copy of datafile. {0}", ex.getMessage()); // No I18N
             StatusDisplayer.getDefault().setStatusText("");
             return;
         }
@@ -179,7 +180,7 @@ public final class ArchiveAction extends CallableSystemAction implements LookupL
         try {
             archiveData = XStreamWrapper.instance().load(archiveFile);
         } catch (Exception ex) {
-            LOG.severe("Error loading data from archive file. " + ex.getMessage()); // No I18N
+            LOG.log(Level.SEVERE, "Error loading data from archive file. {0}", ex.getMessage()); // No I18N
             StatusDisplayer.getDefault().setStatusText("");
             return;
         }
@@ -190,7 +191,7 @@ public final class ArchiveAction extends CallableSystemAction implements LookupL
             if (action.isDone() && action.getDoneDate().before(archiveDate)) {
                 archiveSingleActions.add(action);
             } else {
-                LOG.fine("Removing from archive - action: " + action.getDescription()); // No I18N
+                LOG.log(Level.FINE, "Removing from archive - action: {0}", action.getDescription()); // No I18N
                 action.removeFromParent();
             }
         }
@@ -202,7 +203,7 @@ public final class ArchiveAction extends CallableSystemAction implements LookupL
                 if (project.isDone() && project.getDoneDate().before(archiveDate)) {
                     archiveProjects.add(project);
                 } else {
-                    LOG.fine("Removing from archive - project: " + project.getDescription()); // No I18N
+                    LOG.log(Level.FINE, "Removing from archive - project: {0}", project.getDescription()); // No I18N
                     project.removeFromParent();
                 }
             }
@@ -244,7 +245,7 @@ public final class ArchiveAction extends CallableSystemAction implements LookupL
         try {
             XStreamWrapper.instance().store(archiveData, archiveFile);
         } catch (Exception ex) {
-            LOG.severe("Error storing archive. " + ex.getMessage()); // No I18N
+            LOG.log(Level.SEVERE, "Error storing archive. {0}", ex.getMessage()); // No I18N
             StatusDisplayer.getDefault().setStatusText(""); // No I18N
             return;
         }
@@ -260,14 +261,14 @@ public final class ArchiveAction extends CallableSystemAction implements LookupL
 //      // Remove from data file all archived single singleActions
 //        Project singleActions = data.getRootActions();
 //        for (Action archiveAction : archiveActions) {
-//            LOG.fine("Removing from data - action: " + archiveAction.getDescription()); // No I18N
+//            LOG.log(Level.FINE, "Removing from data - action: {0}", archiveAction.getDescription()); // No I18N
 //            singleActions.remove(archiveAction);
 //        }
 
         // Remove from data file all archived single actions
         Project singleActions = data.getRootActions();
         for (Action a : archiveSingleActions) {
-            LOG.fine("Removing from data - single action: " + a.getDescription()); 
+            LOG.log(Level.FINE, "Removing from data - single action: {0}", a.getDescription());
             singleActions.remove(a);
         }        
 
@@ -276,7 +277,7 @@ public final class ArchiveAction extends CallableSystemAction implements LookupL
 
         // Remove from data file all archived actions
         for (Action archiveAction : archiveActions) {
-            LOG.fine("Removing from data file - archived action: " + archiveAction.getDescription());
+            LOG.log(Level.FINE, "Removing from data file - archived action: {0}", archiveAction.getDescription());
             
             Project dataParent = dataProjectsMap.get(archiveAction.getParent().getID());
             if (dataParent != null) {
@@ -291,7 +292,7 @@ public final class ArchiveAction extends CallableSystemAction implements LookupL
 
         // Remove from data file all archived projects
         for (Project archiveProject : archiveProjects) {
-            LOG.fine("Removing from data file - archived project: " + archiveProject.getDescription());
+            LOG.log(Level.FINE, "Removing from data file - archived project: {0}", archiveProject.getDescription());
             Project dataParent = dataProjectsMap.get(archiveProject.getParent().getID());
             if (dataParent != null) {
                 if (!dataParent.remove(archiveProject)) {
@@ -315,7 +316,7 @@ public final class ArchiveAction extends CallableSystemAction implements LookupL
         for (Thought thought : orphanedThoughts) {
             thoughtManager.remove(thought);
         }
-        LOG.info("Removed from data file: " + orphanedThoughts.size() + " processed thoughts no longer used.");
+        LOG.log(Level.INFO, "Removed from data file: {0} processed thoughts no longer used.", orphanedThoughts.size());
 
 
         saveData(datastore);
@@ -407,7 +408,7 @@ public final class ArchiveAction extends CallableSystemAction implements LookupL
         try {
             ds.store();
         } catch (Exception ex) {
-            LOG.severe("Could not save data. " + ex.getMessage()); // No I18N
+            LOG.log(Level.SEVERE, "Could not save data. {0}", ex.getMessage()); // No I18N
         }
     }
 

--- a/modules/au.com.trgtd.tr.calendar.ical4j/src/au/com/trgtd/tr/calendar/ical4j/ICal4JWrapper.java
+++ b/modules/au.com.trgtd.tr.calendar.ical4j/src/au/com/trgtd/tr/calendar/ical4j/ICal4JWrapper.java
@@ -47,6 +47,7 @@ import net.fortuna.ical4j.model.property.Summary;
 import net.fortuna.ical4j.model.property.Uid;
 import net.fortuna.ical4j.model.property.Version;
 import au.com.trgtd.tr.util.DateUtils;
+import java.util.logging.Level;
 
 /**
  * Wrapper of iCal4j for creating ICalendar files.
@@ -84,7 +85,7 @@ public class ICal4JWrapper {
             } else {
                 vtimezone = timezone.getVTimeZone();                
                 calendar.getComponents().add(vtimezone);
-                LOG.info("Time zone added: " + timezone.getDisplayName());
+                LOG.log(Level.INFO, "Time zone added: {0}", timezone.getDisplayName());
             }
         }
     }
@@ -123,7 +124,7 @@ public class ICal4JWrapper {
             vevent.validate();
             calendar.getComponents().add(vevent);
         } catch (ValidationException ex) {
-            LOG.severe("ValidationException for Event : " + vevent.toString() + "\n" + ex.getMessage());
+            LOG.log(Level.SEVERE, "ValidationException for Event : {0}\n{1}", new Object[]{vevent.toString(), ex.getMessage()});
             ex.printStackTrace(System.err);
         }
 
@@ -177,7 +178,7 @@ public class ICal4JWrapper {
             vevent.validate();
             calendar.getComponents().add(vevent);
         } catch (ValidationException ex) {
-            LOG.severe("ValidationException for Event : " + vevent.toString() + "\n" + ex.getMessage());
+            LOG.log(Level.SEVERE, "ValidationException for Event : {0}\n{1}", new Object[]{vevent.toString(), ex.getMessage()});
             ex.printStackTrace(System.err);
         }
         
@@ -242,7 +243,7 @@ public class ICal4JWrapper {
             vtodo.validate();
             calendar.getComponents().add(vtodo);
         } catch (ValidationException ex) {
-            LOG.severe("ValidationException for ToDO : " + vtodo.toString() + "\n" + ex.getMessage());
+            LOG.log(Level.SEVERE, "ValidationException for ToDO : {0}\n{1}", new Object[]{vtodo.toString(), ex.getMessage()});
             ex.printStackTrace(System.err);
         }
 

--- a/modules/au.com.trgtd.tr.data.recent/src/au/com/trgtd/tr/data/recent/RecentDataFileOpenAction.java
+++ b/modules/au.com.trgtd.tr.data.recent/src/au/com/trgtd/tr/data/recent/RecentDataFileOpenAction.java
@@ -33,6 +33,7 @@ import org.openide.windows.WindowManager;
 import au.com.trgtd.tr.task.activation.ActivatorTaskScheduler;
 import au.com.trgtd.tr.task.recurrence.RecurrenceTaskScheduler;
 import au.com.trgtd.tr.prefs.ui.utils.WindowUtils;
+import java.util.logging.Level;
 
 /**
  * Action to open a recent data file.
@@ -80,7 +81,7 @@ public final class RecentDataFileOpenAction extends AbstractAction {
         try {
             ds.store();
         } catch (Exception ex) {
-            LOG.severe("Datastore store exception: " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Datastore store exception: {0}", ex.getMessage());
         }
 
         // save review actions screens and force reload
@@ -94,7 +95,7 @@ public final class RecentDataFileOpenAction extends AbstractAction {
                     screensDAOProvider.reset();
                 }
             } catch (Exception ex) {
-                LOG.severe("Review Actions screens could not be saved. " + ex.getMessage());                
+                LOG.log(Level.SEVERE, "Review Actions screens could not be saved. {0}", ex.getMessage());
             }
         }        
 

--- a/modules/au.com.trgtd.tr.data/src/au/com/trgtd/tr/data/NewAction.java
+++ b/modules/au.com.trgtd.tr.data/src/au/com/trgtd/tr/data/NewAction.java
@@ -101,7 +101,7 @@ public final class NewAction extends CallableSystemAction {
                     screensDAOProvider.reset();
                 }
             } catch (Exception ex) {
-                LOG.severe("Review Actions screens could not be saved. " + ex.getMessage());                
+                LOG.log(Level.SEVERE, "Review Actions screens could not be saved. {0}", ex.getMessage());
             }
         }        
         

--- a/modules/au.com.trgtd.tr.datastore.xstream2/src/au/com/trgtd/tr/datastore/xstream/XStreamPrefs.java
+++ b/modules/au.com.trgtd.tr.datastore.xstream2/src/au/com/trgtd/tr/datastore/xstream/XStreamPrefs.java
@@ -20,6 +20,7 @@ package au.com.trgtd.tr.datastore.xstream;
 import au.com.trgtd.tr.appl.Constants;
 import au.com.trgtd.tr.appl.UtilsPrefs;
 import java.io.File;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
@@ -61,7 +62,7 @@ public final class XStreamPrefs {
                 }
             }
         } catch (BackingStoreException ex) {
-            LOG.severe("XStream preferences error. " + ex.getMessage());
+            LOG.log(Level.SEVERE, "XStream preferences error. {0}", ex.getMessage());
             Exceptions.printStackTrace(ex);
         }
     }
@@ -98,7 +99,7 @@ public final class XStreamPrefs {
         try {
             instance.prefs.flush();
         } catch (BackingStoreException ex) {
-            LOG.severe("XStream preferences exception. " + ex.getMessage());
+            LOG.log(Level.SEVERE, "XStream preferences exception. {0}", ex.getMessage());
         }
     }
 

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/task/FetchEmailThread.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/task/FetchEmailThread.java
@@ -43,8 +43,10 @@ public final class FetchEmailThread extends Thread {
      */
     @Override
     public void run() {
+//      LOG.log(LogLevel.Info, "Starting email fetch at: {0}", new Date());
         synchronized (SYNCHRONIZE_OBJECT) {
             Email.retrieve();
         }
+//      LOG.log(LogLevel.Info, "Finished email fetch at: {0}", new Date());
     }
 }

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/task/FetchEmailThread.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/task/FetchEmailThread.java
@@ -43,12 +43,8 @@ public final class FetchEmailThread extends Thread {
      */
     @Override
     public void run() {
-//      LOG.info("Starting email fetch at: " + new Date());
-
         synchronized (SYNCHRONIZE_OBJECT) {
             Email.retrieve();
         }
-
-//      LOG.info("Finished email fetch at: " + new Date());
     }
 }

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/utils/RenderableMessage.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/utils/RenderableMessage.java
@@ -64,11 +64,11 @@ public class RenderableMessage implements Renderable {
             return handleMultipart((Multipart) part.getContent());
         }
 
-//        LOG.log(Level.INFO, "EXTRACT PART ({0}) Content Type:{}", n, part.getContentType());
+//        LOG.log(Level.INFO, "EXTRACT PART ({0}) Content Type:{1}", new Object[]{n, part.getContentType()});
 
         if (part.getFileName() != null) {
 
-//            LOG.log(Level.INFO, "EXTRACT PART ({0}) Filename: {1}",n , part.getFileName());
+//            LOG.log(Level.INFO, "EXTRACT PART ({0}) Filename: {1}", new Object[]{n , part.getFileName()});
 
 //            LOG.log(Level.INFO, "EXTRACT PART ({0}) ATTACHMENT", n);
 
@@ -91,7 +91,7 @@ public class RenderableMessage implements Renderable {
 
         if (part.getContentType().startsWith("text/plain")) {
 
-//            LOG.log(Level.INFO, "EXTRACT PART ({0}) TEXT/PLAIN: {1}", n, part.getContent());
+//            LOG.log(Level.INFO, "EXTRACT PART ({0}) TEXT/PLAIN: {1}", new Object[]{n, part.getContent()});
 
             if (bodytext == null) {
                 bodytext = (String) part.getContent();
@@ -103,7 +103,7 @@ public class RenderableMessage implements Renderable {
 
         if (part.getContentType().startsWith("text/html")) {
 
-//            LOG.log(Level.INFO, "EXTRACT PART ({0}) TEXT/HTML: {1}", n, part.getContent());
+//            LOG.log(Level.INFO, "EXTRACT PART ({0}) TEXT/HTML: {1}", new Object[]{n, part.getContent()});
 
             if (bodytext == null) {
                 bodytext = HTML.html2text((String) part.getContent());

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/utils/RenderableMessage.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/utils/RenderableMessage.java
@@ -59,18 +59,18 @@ public class RenderableMessage implements Renderable {
 
         if (part.getContent() instanceof Multipart) {
 
-//            LOG.info("EXTRACT PART (" + n + ") " + "Multipart");
+//            LOG.log(Level.INFO, "EXTRACT PART ({0}) Multipart", n);
 
             return handleMultipart((Multipart) part.getContent());
         }
 
-//        LOG.info("EXTRACT PART (" + n + ") " + "Content Type:" + part.getContentType());
+//        LOG.log(Level.INFO, "EXTRACT PART ({0}) Content Type:{}", n, part.getContentType());
 
         if (part.getFileName() != null) {
 
-//            LOG.info("EXTRACT PART (" + n + ") " + "Filename: " + part.getFileName());
+//            LOG.log(Level.INFO, "EXTRACT PART ({0}) Filename: {1}",n , part.getFileName());
 
-//            LOG.info("EXTRACT PART (" + n + ") " + "ATTACHMENT");
+//            LOG.log(Level.INFO, "EXTRACT PART ({0}) ATTACHMENT", n);
 
             Attachment attachment = new Attachment();
             attachment.setContenttype(part.getContentType());
@@ -91,7 +91,7 @@ public class RenderableMessage implements Renderable {
 
         if (part.getContentType().startsWith("text/plain")) {
 
-//            LOG.info("EXTRACT PART (" + n + ") " + "TEXT/PLAIN: " + part.getContent());
+//            LOG.log(Level.INFO, "EXTRACT PART ({0}) TEXT/PLAIN: {1}", n, part.getContent());
 
             if (bodytext == null) {
                 bodytext = (String) part.getContent();
@@ -103,7 +103,7 @@ public class RenderableMessage implements Renderable {
 
         if (part.getContentType().startsWith("text/html")) {
 
-//            LOG.info("EXTRACT PART (" + n + ") " + "TEXT/HTML: " + part.getContent());
+//            LOG.log(Level.INFO, "EXTRACT PART ({0}) TEXT/HTML: {1}", n, part.getContent());
 
             if (bodytext == null) {
                 bodytext = HTML.html2text((String) part.getContent());
@@ -113,7 +113,7 @@ public class RenderableMessage implements Renderable {
             return true;
         }
 
-////        LOG.info("ATTACHMENT");
+////        LOG.log(Level.INFO, "ATTACHMENT");
 //
 //        Attachment attachment = new Attachment();
 //        attachment.setContenttype(part.getContentType());
@@ -133,13 +133,13 @@ public class RenderableMessage implements Renderable {
 //        attachments.add(attachment);
 //        return true;
 
-//        LOG.warning("EXTRACT PART (" + n + ") " + "NOT HANDLED");
+//        LOG.log(Level.WARNING, "EXTRACT PART ({0}) NOT HANDLED", n);
 
         return false;
     }
 
     private boolean handleMultipart(Multipart mp) throws MessagingException, IOException {
-//      LOG.info("Multipart content type: " + mp.getContentType());
+//      LOG.log(Level.INFO, "Multipart content type: {0}", mp.getContentType());
 
         if (mp.getContentType().startsWith("multipart/alternative")) {
             return handleMultipartAlternative(mp);
@@ -153,7 +153,7 @@ public class RenderableMessage implements Renderable {
             return handleMultipartSigned(mp);
         }
 
-//        LOG.warning("Multipart content could not be handled.");
+//        LOG.log(Level.WARNING, "Multipart content could not be handled.");
 
         return false;
     }

--- a/modules/au.com.trgtd.tr.extract.clean/src/au/com/trgtd/tr/extract/clean/ExtractCleanPrefs.java
+++ b/modules/au.com.trgtd.tr.extract.clean/src/au/com/trgtd/tr/extract/clean/ExtractCleanPrefs.java
@@ -19,6 +19,7 @@ package au.com.trgtd.tr.extract.clean;
 
 import au.com.trgtd.tr.appl.Constants;
 import au.com.trgtd.tr.appl.UtilsPrefs;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
@@ -71,7 +72,7 @@ public class ExtractCleanPrefs {
                 }
             }
         } catch (BackingStoreException ex) {
-            LOG.severe("Extract clean preferences error. " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Extract clean preferences error. {0}", ex.getMessage());
             Exceptions.printStackTrace(ex);
         }
     }
@@ -128,7 +129,7 @@ public class ExtractCleanPrefs {
         try {
             instance.prefs.flush();
         } catch (BackingStoreException ex) {
-            LOG.severe("Extract clean preferences error. " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Extract clean preferences error. {0}", ex.getMessage());
         }
     }
 

--- a/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractAction.java
+++ b/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractAction.java
@@ -34,6 +34,7 @@ import au.com.trgtd.tr.extract.Extract.FormatType;
 import au.com.trgtd.tr.extract.criteria.ValueIDsProviderEnergy;
 import au.com.trgtd.tr.extract.criteria.ValueIDsProviderPriority;
 import au.com.trgtd.tr.extract.criteria.ValueIDsProviderTime;
+import java.util.logging.Level;
 import tr.model.action.Action;
 import tr.model.action.ActionState;
 import tr.model.action.ActionStateASAP;
@@ -75,7 +76,7 @@ public class ExtractAction {
             process(action, out);
             finalise(out);
         } catch (Exception ex) {
-            LOG.severe("Extracting data failed: " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Extracting data failed: {0}", ex.getMessage());
         }
     }
 
@@ -110,7 +111,7 @@ public class ExtractAction {
             processData(action, out);
             LOG.info("Extracting action ... done");
         } catch (Exception ex) {
-            LOG.severe("Extracting action failed: " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Extracting action failed: {0}", ex.getMessage());
         }
 
     }

--- a/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractData.java
+++ b/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractData.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.Vector;
 import java.util.logging.Logger;
 import au.com.trgtd.tr.extract.Extract.FormatType;
+import java.util.logging.Level;
 import tr.model.Data;
 import tr.model.Item.Item;
 import tr.model.action.Action;
@@ -136,7 +137,7 @@ public class ExtractData {
             output();
             LOG.info("Extracting data done");
         } catch (Exception ex) {
-            LOG.severe("Extracting data failed: " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Extracting data failed: {0}", ex.getMessage());
             ex.printStackTrace();
         }
     }

--- a/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractPocketMod.java
+++ b/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractPocketMod.java
@@ -44,6 +44,7 @@ import tr.model.project.Project;
 import tr.model.thought.Thought;
 import tr.model.topic.Topic;
 import au.com.trgtd.tr.util.DateUtils;
+import java.util.logging.Level;
 
 /**
  * Extract data as XML for PocketMod report.
@@ -102,7 +103,7 @@ public class ExtractPocketMod {
             finalise(out);
         } catch (Exception ex) {
             ex.printStackTrace(System.err);
-            LOG.severe("Extracting data failed: " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Extracting data failed: {0}", ex.getMessage());
         }
     }
 
@@ -148,7 +149,7 @@ public class ExtractPocketMod {
             LOG.info("Extracting completed");
         } catch (Exception ex) {
             ex.printStackTrace(System.err);
-            LOG.severe("Extracting failed: " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Extracting failed: {0}", ex.getMessage());
         }
     }
 

--- a/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractProjectDetail.java
+++ b/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractProjectDetail.java
@@ -30,6 +30,7 @@ import java.util.Date;
 import java.util.logging.Logger;
 import org.openide.util.NbBundle;
 import au.com.trgtd.tr.extract.Extract.FormatType;
+import java.util.logging.Level;
 import tr.model.Item.Item;
 import tr.model.action.Action;
 import tr.model.action.ActionStateDelegated;
@@ -73,7 +74,7 @@ public class ExtractProjectDetail {
             process(out, project);
             finalise(out);
         } catch (Exception ex) {
-            LOG.severe("Extracting data failed: " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Extracting data failed: {0}", ex.getMessage());
         }
     }
 

--- a/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractProjects.java
+++ b/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractProjects.java
@@ -32,6 +32,7 @@ import au.com.trgtd.tr.extract.Extract.FormatType;
 import au.com.trgtd.tr.extract.criteria.ValueIDsProviderEnergy;
 import au.com.trgtd.tr.extract.criteria.ValueIDsProviderPriority;
 import au.com.trgtd.tr.extract.criteria.ValueIDsProviderTime;
+import java.util.logging.Level;
 import tr.model.Data;
 import tr.model.action.Action;
 import tr.model.criteria.Value;
@@ -66,7 +67,7 @@ public class ExtractProjects {
             process(data, out);
             finalise(out);
         } catch (Exception ex) {
-            LOG.severe("Extracting data failed: " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Extracting data failed: {0}", ex.getMessage());
         }
     }
 
@@ -101,7 +102,7 @@ public class ExtractProjects {
             processData(data, out);
             LOG.info("Extracting projects ... done");
         } catch (Exception ex) {
-            LOG.severe("Extracting projects failed: " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Extracting projects failed: {0}", ex.getMessage());
         }
 
     }

--- a/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractReferences.java
+++ b/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractReferences.java
@@ -27,6 +27,7 @@ import java.io.Writer;
 import java.text.DateFormat;
 import java.util.logging.Logger;
 import au.com.trgtd.tr.extract.Extract.FormatType;
+import java.util.logging.Level;
 import tr.model.Data;
 import tr.model.information.Information;
 
@@ -51,7 +52,7 @@ public class ExtractReferences {
             process(data, out);
             finalise(out);
         } catch (Exception ex) {
-            LOG.severe("Extracting data failed: " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Extracting data failed: {0}", ex.getMessage());
         }
     }
 
@@ -84,7 +85,7 @@ public class ExtractReferences {
             writeReferences(data, out);
             LOG.info("Extracting references ... done");
         } catch (Exception ex) {
-            LOG.severe("Extracting references failed: " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Extracting references failed: {0}", ex.getMessage());
             ex.printStackTrace();
         }
     }

--- a/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractSingleActions.java
+++ b/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractSingleActions.java
@@ -19,6 +19,7 @@ package au.com.trgtd.tr.extract;
 
 import java.io.File;
 import java.io.Writer;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import tr.model.Data;
 import tr.model.action.Action;
@@ -60,7 +61,7 @@ public class ExtractSingleActions {
             process(out, data);
             ExtractUtils.finalise(out);
         } catch (Exception ex) {
-            LOG.severe("Extracting data failed: " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Extracting data failed: {0}", ex.getMessage());
         }
     }
 

--- a/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractSomedayMaybe.java
+++ b/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractSomedayMaybe.java
@@ -27,6 +27,7 @@ import java.io.Writer;
 import java.text.DateFormat;
 import java.util.logging.Logger;
 import au.com.trgtd.tr.extract.Extract.FormatType;
+import java.util.logging.Level;
 import tr.model.Data;
 import tr.model.future.Future;
 
@@ -51,7 +52,7 @@ public class ExtractSomedayMaybe {
             process(data, out);
             finalise(out);
         } catch (Exception ex) {
-            LOG.severe("Extracting someday/maybe failed: " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Extracting someday/maybe failed: {0}", ex.getMessage());
         }
     }
 
@@ -84,7 +85,7 @@ public class ExtractSomedayMaybe {
             writeItems(data, out);
             LOG.info("Extracting someday/maybe ... done");
         } catch (Exception ex) {
-            LOG.severe("Extracting someday/maybe failed: " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Extracting someday/maybe failed: {0}", ex.getMessage());
             ex.printStackTrace();
         }
     }

--- a/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractThoughts.java
+++ b/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractThoughts.java
@@ -27,6 +27,7 @@ import java.io.Writer;
 import java.text.DateFormat;
 import java.util.logging.Logger;
 import au.com.trgtd.tr.extract.Extract.FormatType;
+import java.util.logging.Level;
 import tr.model.Data;
 import tr.model.thought.Thought;
 
@@ -51,7 +52,7 @@ public class ExtractThoughts {
             process(data, out);
             finalise(out);
         } catch (Exception ex) {
-            LOG.severe("Extracting data failed: " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Extracting data failed: {0}", ex.getMessage());
         }
     }
 
@@ -86,7 +87,7 @@ public class ExtractThoughts {
             writeThoughts(data, out);
             LOG.info("Extracting thoughts ... done");
         } catch (Exception ex) {
-            LOG.severe("Extracting thoughts failed: " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Extracting thoughts failed: {0}", ex.getMessage());
             ex.printStackTrace();
         }
     }

--- a/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/XSL.java
+++ b/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/XSL.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -61,7 +62,7 @@ public class XSL {
             try {
                 outStreamWriter = new OutputStreamWriter(outStream, encoding);
             } catch (Exception ex) {
-                LOG.warning("Encoding " + encoding + " is not supported.");
+                LOG.log(Level.WARNING, "Encoding {0} is not supported.", encoding);
                 encoding = null;
                 outStreamWriter = new OutputStreamWriter(outStream);
             }
@@ -85,7 +86,7 @@ public class XSL {
                     String value = param.getValue();
                     if (value != null && !value.trim().equals("")) {
                         
-                        LOG.info("****** ID: |" + param.id + "| Value: |" + value + "| ******");
+                        LOG.log(Level.INFO, "****** ID: |{0}| Value: |{1}| ******", new Object[]{param.id, value});
                         
                         transformer.setParameter(param.id, value);                        
                     }

--- a/modules/au.com.trgtd.tr.reports.actions.delegated/src/au/com/trgtd/tr/reports/actions/delegated/ReportImpl.java
+++ b/modules/au.com.trgtd.tr.reports.actions.delegated/src/au/com/trgtd/tr/reports/actions/delegated/ReportImpl.java
@@ -43,6 +43,7 @@ import au.com.trgtd.tr.extract.ParamsDialog;
 import tr.model.Data;
 import au.com.trgtd.tr.swing.date.combo.DateItem;
 import au.com.trgtd.tr.util.DateUtils;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import tr.extract.reports.PaperSize;
 
@@ -200,15 +201,15 @@ public class ReportImpl extends au.com.trgtd.tr.extract.Extract {
         File xmlfile = getTmpFile("Actions.xml");
         ExtractActions.process(data, xmlfile);
 
-        LOG.info("==============================================================");
-        LOG.info("Extract file : " + xmlfile.getPath());
-        LOG.info("paramFrom    : " + dateFrom.getTime());
-        LOG.info("paramTo      : " + dateUpTo.getTime());
-        LOG.info("paramCriteria: " + Boolean.parseBoolean(paramCriteria.getValue()));
-        LOG.info("paramSuccess : " + Boolean.parseBoolean(paramSuccess.getValue()));
-        LOG.info("paramProject : " + Boolean.parseBoolean(paramProject.getValue()));
-        LOG.info("paramNotes   : " + Boolean.parseBoolean(paramNotes.getValue()));
-        LOG.info("==============================================================");
+        LOG.log(Level.INFO, "==============================================================");
+        LOG.log(Level.INFO, "Extract file : {0}", xmlfile.getPath());
+        LOG.log(Level.INFO, "paramFrom    : {0}", dateFrom.getTime());
+        LOG.log(Level.INFO, "paramTo      : {0}", dateUpTo.getTime());
+        LOG.log(Level.INFO, "paramCriteria: {0}", Boolean.parseBoolean(paramCriteria.getValue()));
+        LOG.log(Level.INFO, "paramSuccess : {0}", Boolean.parseBoolean(paramSuccess.getValue()));
+        LOG.log(Level.INFO, "paramProject : {0}", Boolean.parseBoolean(paramProject.getValue()));
+        LOG.log(Level.INFO, "paramNotes   : {0}", Boolean.parseBoolean(paramNotes.getValue()));
+        LOG.log(Level.INFO, "==============================================================");
 
 
         JRXmlDataSource xmlDataSource = new JRXmlDataSource(xmlfile, "/data/actions/action");

--- a/modules/au.com.trgtd.tr.reports.actions.doasap/src/au/com/trgtd/tr/reports/actions/doasap/ReportImpl.java
+++ b/modules/au.com.trgtd.tr.reports.actions.doasap/src/au/com/trgtd/tr/reports/actions/doasap/ReportImpl.java
@@ -36,6 +36,7 @@ import au.com.trgtd.tr.extract.ParamBoolean;
 import au.com.trgtd.tr.extract.ParamContext;
 import au.com.trgtd.tr.extract.ParamList;
 import au.com.trgtd.tr.extract.ParamsDialog;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import tr.extract.reports.PaperSize;
 import tr.model.Data;
@@ -128,7 +129,7 @@ public class ReportImpl extends au.com.trgtd.tr.extract.Extract {
         
         File xmlfile = getTmpFile("Actions.xml");
 
-        LOG.info("Extract file: " + xmlfile.getPath());
+        LOG.log(Level.INFO, "Extract file: {0}", xmlfile.getPath());
         
         ExtractActions.process(data, xmlfile);
                             

--- a/modules/au.com.trgtd.tr.sync.device/src/au/com/trgtd/tr/sync/device/usb/TCPConnector.java
+++ b/modules/au.com.trgtd.tr.sync.device/src/au/com/trgtd/tr/sync/device/usb/TCPConnector.java
@@ -187,8 +187,8 @@ final class TCPConnector extends Thread {
             return null;
         }
 
-//      LOG.log(Level.INFO, "SOCKET  LOCAL ADDR: " + socket.getLocalSocketAddress().toString());
-//      LOG.log(Level.INFO, "SOCKET REMOTE ADDR: " + socket.getRemoteSocketAddress().toString());
+//      LOG.log(Level.INFO, "SOCKET  LOCAL ADDR: {0}", socket.getLocalSocketAddress().toString());
+//      LOG.log(Level.INFO, "SOCKET REMOTE ADDR: {0}", socket.getRemoteSocketAddress().toString());
 
         try {
             socket.setReuseAddress(true);

--- a/modules/au.com.trgtd.tr.sync.iphone/src/au/com/trgtd/tr/sync/iphone/SyncHandler100.java
+++ b/modules/au.com.trgtd.tr.sync.iphone/src/au/com/trgtd/tr/sync/iphone/SyncHandler100.java
@@ -20,6 +20,7 @@ package au.com.trgtd.tr.sync.iphone;
 import java.io.BufferedReader;
 import java.io.PrintWriter;
 import java.util.Date;
+import java.util.logging.Level;
 import tr.model.action.Action;
 import tr.model.context.Context;
 import tr.model.thought.Thought;
@@ -73,7 +74,7 @@ public class SyncHandler100 extends SyncHandler {
                 LOG.warning("RECIEVED: Unexpected end of input stream.");
                 return false;
             }
-            LOG.info("RECIEVED:" + inMsg.toString());
+            LOG.log(Level.INFO, "RECIEVED:{0}", inMsg.toString());
 
             switch (inMsg.type) {
                 case Thought: {
@@ -84,7 +85,7 @@ public class SyncHandler100 extends SyncHandler {
                     thought.setTopic(getTopic(msgThought.topic));
                     getData().getThoughtManager().add(thought);
                     nbrThoughtsGot++;
-                    LOG.info("TR added thought: " + thought.getDescription());
+                    LOG.log(Level.INFO, "TR added thought: {0}", thought.getDescription());
                     out.println(log("OK"));
                     updateProgress();
                     break;

--- a/modules/au.com.trgtd.tr.sync.iphone/src/au/com/trgtd/tr/sync/iphone/SyncHandler101.java
+++ b/modules/au.com.trgtd.tr.sync.iphone/src/au/com/trgtd/tr/sync/iphone/SyncHandler101.java
@@ -22,6 +22,7 @@ import java.io.BufferedReader;
 import java.io.PrintWriter;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.logging.Level;
 import tr.model.action.Action;
 import tr.model.context.Context;
 import tr.model.thought.Thought;
@@ -129,7 +130,7 @@ public class SyncHandler101 extends SyncHandler {
                 return false;
             }
 
-            LOG.info("RECIEVED:" + inMsg.toString());
+            LOG.log(Level.INFO, "RECIEVED:{0}", inMsg.toString());
 
             switch (inMsg.type) {
                 case Thought: {
@@ -140,7 +141,7 @@ public class SyncHandler101 extends SyncHandler {
                     thought.setTopic(getTopic(msgThought.topic));
                     getData().getThoughtManager().add(thought);
                     nbrThoughtsGot++;
-                    LOG.info("TR added thought: " + thought.getDescription());
+                    LOG.log(Level.INFO, "TR added thought: {0}", thought.getDescription());
                     send("OK");
                     break;
                 }
@@ -148,11 +149,11 @@ public class SyncHandler101 extends SyncHandler {
                     SyncMsg101.MsgActionUpdate msgActionUpdate = (SyncMsg101.MsgActionUpdate)inMsg;
                     Action action = Services.instance.getAction(msgActionUpdate.id);
                     if (action == null) {
-                        LOG.warning("COULD NOT FIND ACTION WITH ID: " + msgActionUpdate.id);
+                        LOG.log(Level.WARNING, "COULD NOT FIND ACTION WITH ID: {0}", msgActionUpdate.id);
                         break;
                     }
                     if (msgActionUpdate.done) {
-                        LOG.info("TR updated action with id: " + msgActionUpdate.id + " Done set to True");
+                        LOG.log(Level.INFO, "TR updated action with id: {0} Done set to True", msgActionUpdate.id);
                         action.setDone(true);
                         updateActionsToSend();
                     }
@@ -209,7 +210,7 @@ public class SyncHandler101 extends SyncHandler {
             if (!action.isDone()) {
                 return action;
             } else {
-                LOG.info("TR not sending action with id: " + action.getID() + " Was updated to Done");
+                LOG.log(Level.INFO, "TR not sending action with id: {0} Was updated to Done", action.getID());
             }
         }
         return null;

--- a/modules/au.com.trgtd.tr.sync.iphone/src/au/com/trgtd/tr/sync/iphone/SyncHandler102.java
+++ b/modules/au.com.trgtd.tr.sync.iphone/src/au/com/trgtd/tr/sync/iphone/SyncHandler102.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.logging.Level;
 import tr.model.Data;
 import tr.model.action.Action;
 import tr.model.action.ActionStateDelegated;
@@ -110,7 +111,7 @@ public class SyncHandler102 extends SyncHandler {
                 return false;
             }
 
-            LOG.info("RECIEVED:" + inMsg.toString());
+            LOG.log(Level.INFO, "RECIEVED:{0}", inMsg.toString());
 
             switch (inMsg.type) {
                 case Thought: {
@@ -121,7 +122,7 @@ public class SyncHandler102 extends SyncHandler {
                     thought.setTopic(getTopic(msgThought.topic));
                     getData().getThoughtManager().add(thought);
                     nbrThoughtsGot++;
-                    LOG.info("TR added thought: " + thought.getDescription());
+                    LOG.log(Level.INFO, "TR added thought: {0}", thought.getDescription());
                     send("OK");
                     break;
                 }
@@ -129,11 +130,11 @@ public class SyncHandler102 extends SyncHandler {
                     SyncMsg102.MsgActionUpdate msgActionUpdate = (SyncMsg102.MsgActionUpdate) inMsg;
                     Action action = Services.instance.getAction(msgActionUpdate.id);
                     if (action == null) {
-                        LOG.warning("COULD NOT FIND ACTION WITH ID: " + msgActionUpdate.id);
+                        LOG.log(Level.WARNING, "COULD NOT FIND ACTION WITH ID: {0}", msgActionUpdate.id);
                         break;
                     }
                     if (msgActionUpdate.done) {
-                        LOG.info("TR updated action with id: " + msgActionUpdate.id + " Done set to True");
+                        LOG.log(Level.INFO, "TR updated action with id: {0} Done set to True", msgActionUpdate.id);
                         action.setDone(true);
                         updateActionsToSend();
                     }
@@ -284,7 +285,7 @@ public class SyncHandler102 extends SyncHandler {
             if (!action.isDone()) {
                 return action;
             } else {
-                LOG.info("TR not sending action with id: " + action.getID() + " Was updated to Done");
+                LOG.log(Level.INFO, "TR not sending action with id: {0} Was updated to Done", action.getID());
             }
         }
         return null;

--- a/modules/au.com.trgtd.tr.sync.iphone/src/au/com/trgtd/tr/sync/iphone/SyncMsg101.java
+++ b/modules/au.com.trgtd.tr.sync.iphone/src/au/com/trgtd/tr/sync/iphone/SyncMsg101.java
@@ -19,6 +19,7 @@ package au.com.trgtd.tr.sync.iphone;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public abstract class SyncMsg101 {
@@ -75,7 +76,7 @@ public abstract class SyncMsg101 {
             return new MsgActionUpdate(str);
         }
 
-        LOG.warning("UNKNOWN MESSAGE: " + str);
+        LOG.log(Level.WARNING, "UNKNOWN MESSAGE: {0}", str);
         return MSG_UNKNOWN;
     }
 
@@ -200,7 +201,7 @@ public abstract class SyncMsg101 {
         while (!in.ready()) {
         }
         SyncHandler101.tTemp.stop();
-        LOG.info("======> WAITED: " + SyncHandler101.tTemp.getTotal());
+        LOG.log(Level.INFO, "======> WAITED: {0}", SyncHandler101.tTemp.getTotal());
         SyncHandler101.tReadWait.stop();
         // End recording time while stream not ready
 

--- a/modules/au.com.trgtd.tr.sync.iphone/src/au/com/trgtd/tr/sync/iphone/SyncMsg102.java
+++ b/modules/au.com.trgtd.tr.sync.iphone/src/au/com/trgtd/tr/sync/iphone/SyncMsg102.java
@@ -19,6 +19,7 @@ package au.com.trgtd.tr.sync.iphone;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public abstract class SyncMsg102 {
@@ -88,7 +89,7 @@ public abstract class SyncMsg102 {
             return new MsgActionUpdate(str);
         }
 
-        LOG.warning("UNKNOWN MESSAGE: " + str);
+        LOG.log(Level.WARNING, "UNKNOWN MESSAGE: {0}", str);
         return MSG_UNKNOWN;
     }
 

--- a/modules/au.com.trgtd.tr.task.recurrence/src/au/com/trgtd/tr/task/recurrence/RecurrenceTaskThread.java
+++ b/modules/au.com.trgtd.tr.task.recurrence/src/au/com/trgtd/tr/task/recurrence/RecurrenceTaskThread.java
@@ -19,6 +19,7 @@ package au.com.trgtd.tr.task.recurrence;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.openide.util.NbBundle;
 import tr.model.Data;
@@ -89,7 +90,7 @@ final class RecurrenceTaskThread extends Thread {
     
     /* Process the given action. */
     private void process(Action action) {
-//      LOG.info("Processing action: " + action.getID() + " >>> " + action.getDescription());
+//      LOG.log(Level.INFO, "Processing action: {0} >>> {1}", new Object[]{action.getID(), action.getDescription()});
 
         Recurrence recurrence = action.getRecurrence();
         if (recurrence == null) {

--- a/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/ColumnsTableModel.java
+++ b/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/ColumnsTableModel.java
@@ -26,6 +26,7 @@ import org.openide.util.NbBundle;
 import au.com.trgtd.tr.util.Observable;
 import au.com.trgtd.tr.util.Observer;
 import au.com.trgtd.tr.view.actns.screens.columns.ActionsColumn;
+import java.util.logging.Level;
 
 /**
  * Table model for the columns dialog.
@@ -136,7 +137,7 @@ public class ColumnsTableModel extends AbstractTableModel implements Observer {
     /** Sets the data model value at the specified table row and column. */
     @Override
     public void setValueAt(Object object, int row, int column) {
-        LOG.fine("SetValueAt: row = " + row + " col = " + column);
+        LOG.log(Level.FINE, "SetValueAt: row = {0} col = {1}", new Object[]{row, column});
         
         if (column == COLUMN_VISIBLE && object instanceof Boolean) {
             

--- a/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/ReviewActionsTopComponent.java
+++ b/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/ReviewActionsTopComponent.java
@@ -88,6 +88,7 @@ import au.com.trgtd.tr.view.contexts.ContextChangeAction;
 import au.com.trgtd.tr.view.projects.PostponeActionAction;
 import au.com.trgtd.tr.view.projects.SetDoneAction;
 import au.com.trgtd.tr.view.topics.TopicChangeAction;
+import java.util.logging.Level;
 //import org.openide.actions.DeleteAction;
 
 /**
@@ -204,7 +205,7 @@ public final class ReviewActionsTopComponent extends Window implements ActionsPr
 
 //  @Override
 //  protected void componentClosed() {
-//      LOG.info("CLOSED ACTIONS: " + getName());
+//      LOG.log(Level.INFO, "CLOSED ACTIONS: {0}", getName());
 //
 //      // panel.save() moved to componentDeactivated()
 //      panel.save();

--- a/modules/au.com.trgtd.tr.view.overview/src/au/com/trgtd/tr/view/overview/OverviewTopComponent.java
+++ b/modules/au.com.trgtd.tr.view.overview/src/au/com/trgtd/tr/view/overview/OverviewTopComponent.java
@@ -35,6 +35,7 @@ import au.com.trgtd.tr.util.Utils;
 import au.com.trgtd.tr.view.Window;
 import au.com.trgtd.tr.view.overview.Overview.Screen;
 import au.com.trgtd.tr.view.overview.spi.OverviewSVGProvider;
+import java.util.logging.Level;
 
 /**
  * Top component which displays the overview screen.
@@ -71,14 +72,14 @@ public final class OverviewTopComponent extends Window {
         String language = Locale.getDefault().getLanguage();
         String country = Locale.getDefault().getCountry();
 
-        LOG.info("Language: " + language);
-        LOG.info("Country: " + country);
+        LOG.log(Level.INFO, "Language: {0}", language);
+        LOG.log(Level.INFO, "Country: {0}", country);
 
         OverviewSVGProvider generalLanguageProvider = null;
 
         for (OverviewSVGProvider provider : lookup.allInstances()) {
 
-            LOG.info("Provider, language: " + provider.getLanguage() + ", country: " + provider.getCountry());
+            LOG.log(Level.INFO, "Provider, language: {0}, country: {1}", new Object[]{provider.getLanguage(), provider.getCountry()});
 
             if (Utils.equal(provider.getLanguage(), language)) {
                 if (Utils.equal(provider.getCountry(), country)) {

--- a/modules/au.com.trgtd.tr.view.projects/src/au/com/trgtd/tr/view/projects/ExportProject.java
+++ b/modules/au.com.trgtd.tr.view.projects/src/au/com/trgtd/tr/view/projects/ExportProject.java
@@ -25,6 +25,7 @@ import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
@@ -101,7 +102,7 @@ public class ExportProject {
             process(project, writer);
             finalise(writer);
         } catch (Exception ex) {
-            LOG.severe("Export project failed: " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Export project failed: {0}", ex.getMessage());
         }
     }
 
@@ -133,7 +134,7 @@ public class ExportProject {
             out.write("</project>\r\n");
             LOG.info("Export project ... done");
         } catch (Exception ex) {
-            LOG.severe("Export project failed: " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Export project failed: {0}", ex.getMessage());
         }
     }
 

--- a/modules/au.com.trgtd.tr.view.projects/src/au/com/trgtd/tr/view/projects/ExportTemplate.java
+++ b/modules/au.com.trgtd.tr.view.projects/src/au/com/trgtd/tr/view/projects/ExportTemplate.java
@@ -25,6 +25,7 @@ import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
@@ -97,7 +98,7 @@ public class ExportTemplate {
             process(project, writer);
             finalise(writer);
         } catch (Exception ex) {
-            LOG.severe("Export project template failed: " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Export project template failed: {0}", ex.getMessage());
         }
     }
 
@@ -129,7 +130,7 @@ public class ExportTemplate {
             out.write("</project>\r\n");        
             LOG.info("Export project template ... done");
         } catch (Exception ex) {
-            LOG.severe("Export project template failed: " + ex.getMessage());
+            LOG.log(Level.SEVERE, "Export project template failed: {0}", ex.getMessage());
         }
     }
 

--- a/modules/au.com.trgtd.tr.view.projects/src/au/com/trgtd/tr/view/projects/ProjectChildren.java
+++ b/modules/au.com.trgtd.tr.view.projects/src/au/com/trgtd/tr/view/projects/ProjectChildren.java
@@ -37,6 +37,7 @@ import tr.model.action.Action;
 import au.com.trgtd.tr.util.Observable;
 import au.com.trgtd.tr.util.Observer;
 import au.com.trgtd.tr.view.projects.goals.ProjectGoalsNode;
+import java.util.logging.Level;
 
 /**
  * Children of a project node.
@@ -238,7 +239,7 @@ public class ProjectChildren extends Children.Keys implements Observer, ChangeLi
                 try {
                     explorerManager.setSelectedNodes(selectedNodes);
                 } catch (Exception ex) {
-                    LOG.info("Node selection failed. " + ex.getMessage());
+                    LOG.log(Level.INFO, "Node selection failed. {0}", ex.getMessage());
                 }
             });
         }

--- a/modules/tr.model/src/tr/model/DataUpgrade4to5.java
+++ b/modules/tr.model/src/tr/model/DataUpgrade4to5.java
@@ -20,6 +20,7 @@ package tr.model;
 import au.com.trgtd.tr.util.UtilsEmail;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import tr.model.action.Action;
 import tr.model.action.ActionStateDelegated;
@@ -53,11 +54,11 @@ public class DataUpgrade4to5 {
 
     // Upgrade the data.
     private static void upgrade(Data data) {
-        LOG.info("Starting data upgrade version " + OLD_VERSION + " to version " + NEW_VERSION + " ... ");
+        LOG.log(Level.INFO, "Starting data upgrade version {0} to version {1} ... ", new Object[]{OLD_VERSION, NEW_VERSION});
 
         upgradeDelegate(data);
 
-        LOG.info("Finished data upgrade.");
+        LOG.log(Level.INFO, "Finished data upgrade.");
     }
 
     private static void upgradeDelegate(Data data) {
@@ -99,7 +100,7 @@ public class DataUpgrade4to5 {
                 actors.put(to, actor);
             }
             state.setActorID(actor.getID());
-            LOG.info("upgraded delegate: " + to);
+            LOG.log(Level.INFO, "upgraded delegate: {0}", to);
         }
 
 //        // Only create delegate if "to" field is a valid email address
@@ -124,7 +125,7 @@ public class DataUpgrade4to5 {
 //                }
 //                state.setActorID(actor.getID());
 //            }
-//            LOG.info("upgraded delegate: " + to);
+//            LOG.log(Level.INFO, "upgraded delegate: {0}", to);
 //        }
 
     }

--- a/modules/tr.model/src/tr/model/action/Recurrence.java
+++ b/modules/tr.model/src/tr/model/action/Recurrence.java
@@ -815,7 +815,7 @@ public final class Recurrence extends ObservableImpl implements Notable {
 
     /** Removes all occurrences scheduled after the given date. */
     private void removeOccurrencesAfter(Date date) {
-        LOG.fine("Removing recurrent actions after: " + date);
+        LOG.log(Level.FINE, "Removing recurrent actions after: {0}", date);
 
         if (!date.before(DateUtils.MAX_DATE)) {
             return;
@@ -844,7 +844,7 @@ public final class Recurrence extends ObservableImpl implements Notable {
 
                     Date schdDate = schdState.getDate();
                     if (schdDate != null && schdDate.after(endOfDate)) {
-                        LOG.fine("Removing action; Scheduled: " + schdDate + " Description: " + action.getDescription());
+                        LOG.log(Level.FINE, "Removing action; Scheduled: {0} Description: {1}", new Object[]{schdDate, action.getDescription()});
 
                         action.removeFromParent();
                     }


### PR DESCRIPTION
A house-keeping PR: use string templates instead of string concatenation for logging.

Expected to have a minor positive effect on memory consumption.

Note: I applied Netbeans refactorings on Warnings in Netbeans.