### PR TITLE
refactor: Use StringBuilder over StringBuffer and improve usage

### DIFF
--- a/modules/au.com.trgtd.tr.calendar.ical4j.impl/src/au/com/trgtd/tr/calendar/ical4j/impl/ICalendarSynchronizer.java
+++ b/modules/au.com.trgtd.tr.calendar.ical4j.impl/src/au/com/trgtd/tr/calendar/ical4j/impl/ICalendarSynchronizer.java
@@ -199,12 +199,12 @@ public class ICalendarSynchronizer implements CalendarSynchronizer {
                 String descr = project.getDescription();
                 Integer priority = getPriority(project);
                 Date startDate = DateUtils.clearTime(project.getStartDate());
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 if (startDate != null) {
-                    sb.append("Start: " + Constants.DATE_FORMAT_FIXED.format(startDate) + "\r\n");
+                    sb.append("Start: ").append(Constants.DATE_FORMAT_FIXED.format(startDate)).append("\r\n");
                 }
                 if (dueDate != null) {
-                    sb.append("Due: " + Constants.DATE_FORMAT_FIXED.format(dueDate) + "\r\n");
+                    sb.append("Due: ").append(Constants.DATE_FORMAT_FIXED.format(dueDate)).append("\r\n");
                 }
                 String notes = sb.toString() + getNotes(project);
                 iCalProject.createAllDayEvent(uid, dueDate, descr, notes, null, priority);
@@ -265,12 +265,12 @@ public class ICalendarSynchronizer implements CalendarSynchronizer {
         if (CalendarPrefs.isInactiveAsTodo()) {
             ical.createToDo(uid, startDate, dueDate, descr, getNotes(action), context, priority);
         } else {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             if (startDate != null) {
-                sb.append("Start: " + Constants.DATE_FORMAT_FIXED.format(startDate) + "\r\n");
+                sb.append("Start: ").append(Constants.DATE_FORMAT_FIXED.format(startDate)).append("\r\n");
             }
             if (dueDate != null) {
-                sb.append("Due: " + Constants.DATE_FORMAT_FIXED.format(dueDate) + "\r\n");
+                sb.append("Due: ").append(Constants.DATE_FORMAT_FIXED.format(dueDate)).append("\r\n");
             }
             String notes = sb.toString() + getNotes(action);
             ical.createAllDayEvent(uid, actionDate, descr, notes, context, priority);
@@ -381,17 +381,17 @@ public class ICalendarSynchronizer implements CalendarSynchronizer {
     }
 
     private static String getNotes(Action action) {
-        StringBuffer notes = new StringBuffer();
+        StringBuilder notes = new StringBuilder();
         notes.append(getContext(action));
         if (action.isSingleAction()) {
             Thought thought = action.getThought();
             if (thought != null) {
-                notes.append(" {" + thought.getDescription() + "}");
+                notes.append(" {").append(thought.getDescription()).append("}");
             }
         } else {
             Project project = (Project) action.getParent();
             if (project != null) {
-                notes.append(" [" + project.getDescription() + "]");
+                notes.append(" [").append(project.getDescription()).append("]");
             }
         }
         notes.append("\r\n");
@@ -400,10 +400,10 @@ public class ICalendarSynchronizer implements CalendarSynchronizer {
     }
 
     private static String getNotes(Project project) {
-        StringBuffer notes = new StringBuffer();
+        StringBuilder notes = new StringBuilder();
         Project parent = (Project) project.getParent();
         if (parent != null) {
-            notes.append("[" + parent.getDescription() + "]\r\n");
+            notes.append("[").append(parent.getDescription()).append("]\r\n");
         }
         notes.append(project.getNotes());
         return notes.toString();

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/EmailUtils.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/EmailUtils.java
@@ -290,7 +290,7 @@ public class EmailUtils {
 //            if (content instanceof String) {
 //                return (String) content;
 //            } else if (content instanceof Multipart) {
-//                StringBuffer sb = new StringBuffer();
+//                StringBuilder sb = new StringBuilder();
 //                Multipart mp = (Multipart) content;
 //                for (int i = 0; i < mp.getCount(); i++) {
 //                    BodyPart bp = mp.getBodyPart(i);

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
@@ -909,14 +909,14 @@ public class Pop3 {
 
             String ctype = part.getContentType();
             ContentType xctype = new ContentType(ctype.toLowerCase());
-            StringBuffer buffer = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
 
             if (xctype.match("text/plain") || xctype.match("TEXT/PLAIN")) {
                 BufferedReader xreader = getTextReader(part);
                 for (String xline; (xline = xreader.readLine()) != null;) {
-                    buffer.append(xline + '\n');
+                    sb.append(xline).append('\n');
                 }
-                body = buffer.toString();
+                body = sb.toString();
             } else {
 
 
@@ -936,7 +936,7 @@ public class Pop3 {
          */
         public static String getBodyHandleMultipart(Multipart multipart) throws MessagingException, IOException {
             String body = null;
-            StringBuffer buffer = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
 
             // boucle sur les parties d'un message...
             for (int i = 0, n = multipart.getCount(); i < n; i++) {
@@ -955,9 +955,9 @@ public class Pop3 {
                 if ((xctype.match("text/plain") || xctype.match("TEXT/PLAIN")) && disposition == null) {
                     BufferedReader xreader = getTextReader(part);
                     for (String xline; (xline = xreader.readLine()) != null;) {
-                        buffer.append(xline + '\n');
+                        sb.append(xline).append('\n');
                     }
-                    body = buffer.toString();
+                    body = sb.toString();
                 }
             }
 
@@ -995,7 +995,7 @@ public class Pop3 {
          */
         public static String getBodyHandleMultipart(Multipart multipart, String contentType) throws MessagingException, IOException {
             String body = null;
-            StringBuffer buffer = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
 
             // boucle sur les parties d'un message...
             for (int i = 0, n = multipart.getCount(); i < n; i++) {
@@ -1014,9 +1014,9 @@ public class Pop3 {
                 if (xctype.match(contentType) && disposition == null) {
                     BufferedReader xreader = getTextReader(part);
                     for (String xline; (xline = xreader.readLine()) != null;) {
-                        buffer.append(xline + '\n');
+                        sb.append(xline).append('\n');
                     }
-                    body = buffer.toString();
+                    body = sb.toString();
                 }
             }
 
@@ -1340,7 +1340,7 @@ public class Pop3 {
         }
 
         private String tohexString(byte abyte0[], int i, int j) {
-            StringBuffer stringbuffer = new StringBuffer(i * 2);
+            StringBuilder sb = new StringBuilder(i * 2);
             for (int l = 0; l < i; l++) {
                 int k;
                 if (abyte0[l + j] < 0) {
@@ -1348,11 +1348,11 @@ public class Pop3 {
                 } else {
                     k = abyte0[l + j];
                 }
-                stringbuffer.insert(2 * l, halfBytetoHex(k / 16));
-                stringbuffer.insert(2 * l + 1, halfBytetoHex(k - 16 * (k / 16)));
+                sb.insert(2 * l, halfBytetoHex(k / 16));
+                sb.insert(2 * l + 1, halfBytetoHex(k - 16 * (k / 16)));
             }
 
-            return stringbuffer.toString();
+            return sb.toString();
         }
 
         private char halfBytetoHex(int i) {

--- a/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractAction.java
+++ b/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractAction.java
@@ -240,12 +240,12 @@ public class ExtractAction {
             }
             out.write("<schd-date-idx>" + (s.getDate() == null ? Long.MAX_VALUE : s.getDate().getTime()) + "</schd-date-idx>");
             if (s.getDurationHours() > 0 || s.getDurationMinutes() > 0) {
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 if (s.getDurationHours() > 0) {
-                    sb.append(s.getDurationHours() + "h");
+                    sb.append(s.getDurationHours()).append("h");
                 }
                 if (s.getDurationMinutes() > 0) {
-                    sb.append(s.getDurationMinutes() + "m");
+                    sb.append(s.getDurationMinutes()).append("m");
                 }
                 out.write("<duration>" + sb.toString() + "</duration>\r\n");
             }

--- a/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractProjectDetail.java
+++ b/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractProjectDetail.java
@@ -225,13 +225,23 @@ public class ExtractProjectDetail {
         StringBuilder sb = new StringBuilder();
         if (a.isStateASAP()) {
             sb.append("\u2605");
-            sb.append(a.getDueDate() == null ? "" : " " + NbBundle.getMessage(ExtractProjectDetail.class, "Due") + ": " + DFN.format(a.getDueDate()));
+            if (a.getDueDate() != null)
+                sb.append(" ")
+                        .append(NbBundle.getMessage(ExtractProjectDetail.class, "Due"))
+                        .append(": ").append(DFN.format(a.getDueDate()));
         } else if (a.isStateDelegated()) {
             ActionStateDelegated s = (ActionStateDelegated) a.getState();
             sb.append("\u261E");
-            sb.append(s.getTo() == null ? "" : " " + escape(s.getTo()));
-            sb.append(s.getDate() == null ? "" : " " + NbBundle.getMessage(ExtractProjectDetail.class, "Followup_Abbrev") + ": " + DFN.format(s.getDate()));
-            sb.append(a.getDueDate() == null ? "" : " " + NbBundle.getMessage(ExtractProjectDetail.class, "Due") + ": " + DFN.format(a.getDueDate()));
+            if (s.getTo() != null)
+                sb.append(" ").append(escape(s.getTo()));
+            if (s.getDate() != null)
+                sb.append(" ")
+                        .append(NbBundle.getMessage(ExtractProjectDetail.class, "Followup_Abbrev"))
+                        .append(": ").append(DFN.format(s.getDate()));
+            if (a.getDueDate() != null)
+                sb.append(" ")
+                        .append(NbBundle.getMessage(ExtractProjectDetail.class, "Due"))
+                        .append(": ").append(DFN.format(a.getDueDate()));
         } else if (a.isStateScheduled()) {
             ActionStateScheduled s = (ActionStateScheduled) a.getState();
             sb.append(s.getRecurrence() == null ? "\u2637" : "\u27F3");
@@ -251,8 +261,14 @@ public class ExtractProjectDetail {
             }
         } else if (a.isStateInactive()) {
             sb.append("\u2606");
-            sb.append(a.getStartDate() == null ? "" : " " + NbBundle.getMessage(ExtractProjectDetail.class, "Start") + ": " + DFN.format(a.getStartDate()));
-            sb.append(a.getDueDate() == null ? "" : " " + NbBundle.getMessage(ExtractProjectDetail.class, "Due") + ": " + DFN.format(a.getDueDate()));
+            if (a.getStartDate() != null)
+                sb.append(" ")
+                        .append(NbBundle.getMessage(ExtractProjectDetail.class, "Start"))
+                        .append(": ").append(DFN.format(a.getStartDate()));
+            if (a.getDueDate() != null)
+                sb.append(" ")
+                        .append(NbBundle.getMessage(ExtractProjectDetail.class, "Due"))
+                        .append(": ").append(DFN.format(a.getDueDate()));
         }
         return sb.length() == 0 ? "" : sb.toString();
     }

--- a/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractProjectDetail.java
+++ b/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractProjectDetail.java
@@ -222,7 +222,7 @@ public class ExtractProjectDetail {
     }
 
     private static synchronized String getState(Action a) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if (a.isStateASAP()) {
             sb.append("\u2605");
             sb.append(a.getDueDate() == null ? "" : " " + NbBundle.getMessage(ExtractProjectDetail.class, "Due") + ": " + DFN.format(a.getDueDate()));
@@ -243,10 +243,10 @@ public class ExtractProjectDetail {
             if (s.getDurationHours() > 0 || s.getDurationMinutes() > 0) {
                 sb.append(" ");
                 if (s.getDurationHours() > 0) {
-                    sb.append(s.getDurationHours() + "h");
+                    sb.append(s.getDurationHours()).append("h");
                 }
                 if (s.getDurationMinutes() > 0) {
-                    sb.append(s.getDurationMinutes() + "m");
+                    sb.append(s.getDurationMinutes()).append("m");
                 }
             }
         } else if (a.isStateInactive()) {
@@ -274,7 +274,7 @@ public class ExtractProjectDetail {
     }
 
 //    private static final String getIndent(int level) {
-//        StringBuffer sb = new StringBuffer();
+//        StringBuilder sb = new StringBuilder();
 //        for (int i = 0; i < level; i++) {
 //            sb.append("  ");
 //        }

--- a/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractProjectOutline.java
+++ b/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractProjectOutline.java
@@ -264,13 +264,23 @@ public class ExtractProjectOutline {
         StringBuilder sb = new StringBuilder();
         if (a.isStateASAP()) {
             sb.append("\u2605");
-            sb.append(a.getDueDate() == null ? "" : " " + NbBundle.getMessage(ExtractProjectOutline.class, "Due") + ": " + DFN.format(a.getDueDate()));
+            if (a.getDueDate() != null)
+                sb.append(" ")
+                        .append(NbBundle.getMessage(ExtractProjectOutline.class, "Due"))
+                        .append(": ").append(DFN.format(a.getDueDate()));
         } else if (a.isStateDelegated()) {
             ActionStateDelegated s = (ActionStateDelegated) a.getState();
             sb.append("\u261E");
-            sb.append(s.getTo() == null ? "" : " " + escape(s.getTo()));
-            sb.append(s.getDate() == null ? "" : " " + NbBundle.getMessage(ExtractProjectOutline.class, "Followup_Abbrev") + ": " + DFN.format(s.getDate()));
-            sb.append(a.getDueDate() == null ? "" : " " + NbBundle.getMessage(ExtractProjectOutline.class, "Due") + ": " + DFN.format(a.getDueDate()));
+            if (s.getTo() != null)
+                sb.append(" ").append(escape(s.getTo()));
+            if (s.getDate() != null)
+                sb.append(" ")
+                        .append(NbBundle.getMessage(ExtractProjectOutline.class, "Followup_Abbrev"))
+                        .append(": ").append(DFN.format(s.getDate()));
+             if (a.getDueDate() != null)
+                sb.append(" ")
+                        .append(NbBundle.getMessage(ExtractProjectOutline.class, "Due"))
+                        .append(": ").append(DFN.format(a.getDueDate()));
         } else if (a.isStateScheduled()) {
             ActionStateScheduled s = (ActionStateScheduled) a.getState();
             sb.append(s.getRecurrence() == null ? "\u2637" : "\u27F3");
@@ -290,8 +300,14 @@ public class ExtractProjectOutline {
             }
         } else if (a.isStateInactive()) {
             sb.append("\u2606");
-            sb.append(a.getStartDate() == null ? "" : " " + NbBundle.getMessage(ExtractProjectOutline.class, "Start") + ": " + DFN.format(a.getStartDate()));
-            sb.append(a.getDueDate() == null ? "" : " " + NbBundle.getMessage(ExtractProjectOutline.class, "Due") + ": " + DFN.format(a.getDueDate()));
+            if (a.getStartDate() != null)
+                sb.append(" ")
+                        .append(NbBundle.getMessage(ExtractProjectOutline.class, "Start"))
+                        .append(": ").append(DFN.format(a.getStartDate()));
+            if (a.getDueDate() != null)
+                sb.append(" ")
+                        .append(NbBundle.getMessage(ExtractProjectOutline.class, "Due"))
+                        .append(": ").append(DFN.format(a.getDueDate()));
         }
         return sb.length() == 0 ? "" : sb.toString();
     }

--- a/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractUtils.java
+++ b/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractUtils.java
@@ -77,13 +77,23 @@ public class ExtractUtils {
         StringBuilder sb = new StringBuilder();
         if (a.isStateASAP()) {
             sb.append("\u2605");
-            sb.append(a.getDueDate() == null ? "" : " " + org.openide.util.NbBundle.getMessage(ExtractUtils.class, "Due") + ": " + dfn.format(a.getDueDate()));
+            if (a.getDueDate() != null)
+                sb.append(" ")
+                        .append(org.openide.util.NbBundle.getMessage(ExtractUtils.class, "Due"))
+                        .append(": ").append(dfn.format(a.getDueDate()));
         } else if (a.isStateDelegated()) {
             ActionStateDelegated s = (ActionStateDelegated) a.getState();
             sb.append("\u261E");
-            sb.append(s.getTo() == null ? "" : " " + escape(s.getTo()));
-            sb.append(s.getDate() == null ? "" : " " + org.openide.util.NbBundle.getMessage(ExtractUtils.class, "Followup_Abbrev") + ": " + dfn.format(s.getDate()));
-            sb.append(a.getDueDate() == null ? "" : " " + org.openide.util.NbBundle.getMessage(ExtractUtils.class, "Due") + ": " + dfn.format(a.getDueDate()));
+            if (s.getTo() != null)
+                sb.append(" ").append(escape(s.getTo()));
+            if (s.getDate() != null)
+                sb.append(" ")
+                        .append(org.openide.util.NbBundle.getMessage(ExtractUtils.class, "Followup_Abbrev"))
+                        .append(": ").append(dfn.format(s.getDate()));
+            if (a.getDueDate() != null)
+                sb.append(" ")
+                        .append(org.openide.util.NbBundle.getMessage(ExtractUtils.class, "Due"))
+                        .append(": ").append(dfn.format(a.getDueDate()));
         } else if (a.isStateScheduled()) {
             ActionStateScheduled s = (ActionStateScheduled) a.getState();
             sb.append(s.getRecurrence() == null ? "\u2637" : "\u27F3");
@@ -103,8 +113,14 @@ public class ExtractUtils {
             }
         } else if (a.isStateInactive()) {
             sb.append("\u2606");
-            sb.append(a.getStartDate() == null ? "" : " " + org.openide.util.NbBundle.getMessage(ExtractUtils.class, "Start") + ": " + dfn.format(a.getStartDate()));
-            sb.append(a.getDueDate() == null ? "" : " " + org.openide.util.NbBundle.getMessage(ExtractUtils.class, "Due") + ": " + dfn.format(a.getDueDate()));
+            if (a.getStartDate() != null)
+                sb.append(" ")
+                        .append(org.openide.util.NbBundle.getMessage(ExtractUtils.class, "Start"))
+                        .append(": ").append(dfn.format(a.getStartDate()));
+            if (a.getDueDate() != null)
+                sb.append(" ")
+                        .append(org.openide.util.NbBundle.getMessage(ExtractUtils.class, "Due"))
+                        .append(": ").append(dfn.format(a.getDueDate()));
         }
         return sb.length() == 0 ? "" : sb.toString();
     }

--- a/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractUtils.java
+++ b/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ExtractUtils.java
@@ -74,7 +74,7 @@ public class ExtractUtils {
     }    
     
     public static synchronized String getState(Action a, DateFormat dfn, DateFormat dft) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if (a.isStateASAP()) {
             sb.append("\u2605");
             sb.append(a.getDueDate() == null ? "" : " " + org.openide.util.NbBundle.getMessage(ExtractUtils.class, "Due") + ": " + dfn.format(a.getDueDate()));
@@ -95,10 +95,10 @@ public class ExtractUtils {
             if (s.getDurationHours() > 0 || s.getDurationMinutes() > 0) {
                 sb.append(" ");
                 if (s.getDurationHours() > 0) {
-                    sb.append(s.getDurationHours() + "h");
+                    sb.append(s.getDurationHours()).append("h");
                 }
                 if (s.getDurationMinutes() > 0) {
-                    sb.append(s.getDurationMinutes() + "m");
+                    sb.append(s.getDurationMinutes()).append("m");
                 }
             }
         } else if (a.isStateInactive()) {
@@ -127,14 +127,14 @@ public class ExtractUtils {
     }
 
     public static synchronized String getDuration(ActionStateScheduled s) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if (s.getDurationHours() > 0 || s.getDurationMinutes() > 0) {
             sb.append(" ");
             if (s.getDurationHours() > 0) {
-                sb.append(s.getDurationHours() + "h");
+                sb.append(s.getDurationHours()).append("h");
             }
             if (s.getDurationMinutes() > 0) {
-                sb.append(s.getDurationMinutes() + "m");
+                sb.append(s.getDurationMinutes()).append("m");
             }
         }
         return sb.toString();

--- a/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ParamProject.java
+++ b/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ParamProject.java
@@ -71,12 +71,12 @@ public class ParamProject extends Param {
             return;
         }
         
-        StringBuffer display = new StringBuffer();
+        StringBuilder display = new StringBuilder();
         display.append("<HTML>");
         if (project.isDone()) {
             display.append("<STRIKE>");
         }
-        display.append(indent + project.getDescription());
+        display.append(indent).append(project.getDescription());
         if (project.isDone()) {
             display.append("</STRIKE>");
         }

--- a/modules/au.com.trgtd.tr.reports.actions.delegated/src/au/com/trgtd/tr/reports/actions/delegated/ReportImpl.java
+++ b/modules/au.com.trgtd.tr.reports.actions.delegated/src/au/com/trgtd/tr/reports/actions/delegated/ReportImpl.java
@@ -168,9 +168,9 @@ public class ReportImpl extends au.com.trgtd.tr.extract.Extract {
         if (DateUtils.isSameDay(dateFrom, dateUpTo)) {
             rparams.put("paramDateRangeText", " For: " + DF.format(dateFrom));
         } else {
-            StringBuffer sb = new StringBuffer();
-            sb.append("From: " + (dateFrom.getTime() == DateItem.EARLIEST.value ? "Earliest" : DF.format(dateFrom)));
-            sb.append("  To: " + (dateUpTo.getTime() == DateItem.LATEST.value ? "Latest" : DF.format(dateUpTo)));
+            StringBuilder sb = new StringBuilder();
+            sb.append("From: ").append(dateFrom.getTime() == DateItem.EARLIEST.value ? "Earliest" : DF.format(dateFrom));
+            sb.append("  To: ").append(dateUpTo.getTime() == DateItem.LATEST.value ? "Latest" : DF.format(dateUpTo));
             rparams.put("paramDateRangeText", sb.toString());
         }
         rparams.put("paramFrom", dateFrom.getTime());

--- a/modules/au.com.trgtd.tr.reports.actions.scheduled/src/au/com/trgtd/tr/reports/actions/scheduled/ReportImpl.java
+++ b/modules/au.com.trgtd.tr.reports.actions.scheduled/src/au/com/trgtd/tr/reports/actions/scheduled/ReportImpl.java
@@ -163,7 +163,7 @@ public class ReportImpl extends au.com.trgtd.tr.extract.Extract {
         if (DateUtils.isSameDay(dateFrom, dateUpTo)) {
             rparams.put("paramDateRangeText", " For: " + DF.format(dateFrom));
         } else {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             sb.append("From: ");
             sb.append(dateFrom.getTime() == DateItem.EARLIEST.value ? "Earliest" : DF.format(dateFrom));
             sb.append(" To: ");

--- a/modules/au.com.trgtd.tr.reports.done/src/au/com/trgtd/tr/reports/done/ReportImpl.java
+++ b/modules/au.com.trgtd.tr.reports.done/src/au/com/trgtd/tr/reports/done/ReportImpl.java
@@ -175,7 +175,7 @@ public class ReportImpl extends au.com.trgtd.tr.extract.Extract {
         if (DateUtils.isSameDay(dateFrom, dateUpTo)) {
             rparams.put("paramDateRangeText", " For: " + DF.format(dateFrom));
         } else {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             sb.append("From: ");
             sb.append(dateFrom.getTime() == DateItem.EARLIEST.value ? "Earliest" : DF.format(dateFrom));
             sb.append(" To: ");

--- a/modules/au.com.trgtd.tr.sync.iphone/src/au/com/trgtd/tr/sync/iphone/SyncMsg100.java
+++ b/modules/au.com.trgtd.tr.sync.iphone/src/au/com/trgtd/tr/sync/iphone/SyncMsg100.java
@@ -122,7 +122,7 @@ public abstract class SyncMsg100 {
         public final String topic;
         public MsgThought(String firstLine, BufferedReader in) {
             super(Type.Thought);
-            StringBuffer sb = new StringBuffer(SyncUtils.unEscape(firstLine.trim()));
+            StringBuilder sb = new StringBuilder(SyncUtils.unEscape(firstLine.trim()));
             while (!sb.toString().matches(RE)) {
                 String nextLine;
                 try {
@@ -133,7 +133,7 @@ public abstract class SyncMsg100 {
                 if (nextLine == null) {
                     break;
                 }
-                sb.append("\n" + SyncUtils.unEscape(nextLine.trim()));
+                sb.append("\n").append(SyncUtils.unEscape(nextLine.trim()));
             }
             msg = sb.toString();
             title = SyncUtils.getFieldValue("Title", msg);

--- a/modules/tr.model/src/tr/model/ICalendar.java
+++ b/modules/tr.model/src/tr/model/ICalendar.java
@@ -103,17 +103,17 @@ public class ICalendar {
         
         String context = action.getContext().getName();
         
-        StringBuffer notes = new StringBuffer();
+        StringBuilder notes = new StringBuilder();
         notes.append(context);
         if (action.isSingleAction()) {
             Thought thought = action.getThought();
             if (thought != null) {
-                notes.append(" {" + thought.getDescription() + "}");
+                notes.append(" {").append(thought.getDescription()).append("}");
             }
         } else {
             Project project = (Project)action.getParent();
             if (project != null) {
-                notes.append(" [" + project.getDescription() + "]");
+                notes.append(" [").append(project.getDescription()).append("]");
             }
         }
         notes.append("\r\n");

--- a/modules/tr.model/src/tr/model/action/PeriodMonth.java
+++ b/modules/tr.model/src/tr/model/action/PeriodMonth.java
@@ -158,9 +158,9 @@ public class PeriodMonth extends Period {
         
         Collections.sort(selectedDays);
         
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (int i = 0; i < selectedDays.size(); i++) {
-            sb.append((i > 0 ? "," : "") + selectedDays.get(i));
+            sb.append(i > 0 ? "," : "").append(selectedDays.get(i));
         }
         
         return sb.toString();

--- a/modules/tr.model/src/tr/model/action/PeriodYear.java
+++ b/modules/tr.model/src/tr/model/action/PeriodYear.java
@@ -136,10 +136,10 @@ public class PeriodYear extends Period {
 
         Collections.sort(selectedMonths);
 
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         
         for (int i = 0; i < selectedMonths.size(); i++) {
-            sb.append((i > 0 ? "," : "") + MONTHS_TEXT[selectedMonths.get(i)]);
+            sb.append(i > 0 ? "," : "").append(MONTHS_TEXT[selectedMonths.get(i)]);
         }
 
         return sb.toString();


### PR DESCRIPTION
A house-keeping PR: Use StringBuilder instead of StringBuffer (faster) and avoid String concatenation by using chained appends instaead of `+`.

Expected to have a minor positive effect on memory consumption and perforrmance.

Note: I applied Netbeans refactorings on Warnings in Netbeans - except for the second commit, where a manual refactoring was needed to pull out the ternary if logic inside the append method and only call the append method (w/o string concatenation) when the relevant value is not null.