### PR TITLE
Shift synchronization in ObservableImpl

### DIFF
--- a/modules/au.com.trgtd.tr.util/src/au/com/trgtd/tr/util/ObservableImpl.java
+++ b/modules/au.com.trgtd.tr.util/src/au/com/trgtd/tr/util/ObservableImpl.java
@@ -18,6 +18,9 @@
 package au.com.trgtd.tr.util;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.WeakHashMap;
 
 /**
@@ -33,7 +36,7 @@ public class ObservableImpl implements Observable, Serializable {
 
     private static final long serialVersionUID = 1;
 
-    private transient WeakHashMap<Observer, Object> observers;
+    private transient Map<Observer, Object> observers;
 
     /**
      * Constructs a default instance.
@@ -49,12 +52,12 @@ public class ObservableImpl implements Observable, Serializable {
      * @param observer The observer to add.
      */
     @Override
-    public synchronized void addObserver(Observer observer) {
+    public void addObserver(Observer observer) {
         if (observer == null) {
             return;
         }
         if (observers == null) {
-            observers = new WeakHashMap<>();
+            observers = Collections.synchronizedMap(new WeakHashMap<>());
         }
         observers.put(observer, null);
     }
@@ -65,7 +68,7 @@ public class ObservableImpl implements Observable, Serializable {
      * @param observer The observer to remove.
      */
     @Override
-    public synchronized void removeObserver(Observer observer) {
+    public void removeObserver(Observer observer) {
         if (observer == null || observers == null) {
             return;
         }
@@ -76,7 +79,7 @@ public class ObservableImpl implements Observable, Serializable {
      * Removes all observers from the list.
      */
     @Override
-    public synchronized void removeObservers() {
+    public void removeObservers() {
         if (observers == null) {
             return;
         }
@@ -87,7 +90,7 @@ public class ObservableImpl implements Observable, Serializable {
      * Override to reset all child observers.
      */
     @Override
-    public synchronized void resetObservers() {
+    public void resetObservers() {
     }
 
     /**
@@ -107,20 +110,12 @@ public class ObservableImpl implements Observable, Serializable {
      * @param observable The observable.
      * @param object The object or null.
      */
-    public synchronized void notifyObservers(Observable observable, Object object) {
+    public void notifyObservers(Observable observable, Object object) {
         if (observers == null) {
             return;
         }
-//        for (Observer observer : observers.keySet()) {
-//            observer.update(observable, object);
-//        }
-
-        Observer[] arr = observers.keySet().toArray(new Observer[0]);
-        for (Observer o : arr) {
-            if (o != null) {
-                o.update(observable, object);                
-            }
+        for (Observer observer : new HashSet<>(observers.keySet())) {
+            observer.update(observable, object);
         }
     }
-
 }

--- a/modules/au.com.trgtd.tr.util/test/unit/src/au/com/trgtd/tr/util/ObservableImplTest.java
+++ b/modules/au.com.trgtd.tr.util/test/unit/src/au/com/trgtd/tr/util/ObservableImplTest.java
@@ -1,0 +1,231 @@
+/*
+ * ThinkingRock, a project management tool for Personal Computers.
+ * Copyright (C) 2006 Avente Pty Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package au.com.trgtd.tr.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ObservableImplTest {
+
+    private Impl sut;
+    private List<String> notifications;
+
+    private final AtomicLong counter = new AtomicLong();
+    private final List logs = Collections.synchronizedList(new ArrayList<String>());
+
+    private final Observer fakeObserver1 = fakeObserver(1);
+    private final Observer fakeObserver2 = fakeObserver(2);
+
+    @Before
+    public void setUp() {
+        sut = new Impl();
+        notifications = new ArrayList<>();
+        counter.set(0);
+        logs.clear();
+    }
+
+    @Test
+    public void callingRemoveObserversOnObservableWithoutObservers() {
+        sut.removeObservers();
+        assertEquals(0, notifications.size());
+    }
+
+    @Test
+    public void callingRemoveObserverOnObservableWithoutObservers() {
+        sut.removeObserver(fakeObserver1);
+        assertEquals(0, notifications.size());
+    }
+
+    @Test
+    public void callingRemoveObserverWithNullObserver() {
+        sut.removeObserver(null);
+        assertEquals(0, notifications.size());
+    }
+
+    @Test
+    public void callingNotifyObserverWithNullObserver() {
+        sut.notifyObservers(null);
+        assertEquals(0, notifications.size());
+    }
+
+    @Test
+    public void addingObservableDoesNotNotify() {
+        sut.addObserver(fakeObserver1);
+        assertEquals(0, notifications.size());
+    }
+
+    @Test
+    public void givenImplWithObserver_whenNotifiying_notifies() {
+        sut.addObserver(fakeObserver1);
+
+        sut.notifyObservers(fakeObservable);
+
+        assertEquals(1, notifications.size());
+        assertEquals("fo1 - null", notifications.get(0));
+    }
+
+    @Test
+    public void givenImplWithObserver_whenNotifiying_notifies2() {
+        sut.addObserver(fakeObserver1);
+
+        sut.notifyObservers(fakeObservable, "bar");
+
+        assertEquals(1, notifications.size());
+        assertEquals("fo1 - bar", notifications.get(0));
+    }
+
+    @Test
+    public void givenImplWithTwoObservers_whenNotifyingObservers_notifiesBoth() {
+        sut.addObserver(fakeObserver1);
+        sut.addObserver(fakeObserver2);
+
+        sut.notifyObservers(fakeObservable);
+
+        assertEquals(2, notifications.size());
+    }
+
+    @Test
+    public void canConcurrentlyModifyObserversWhileNotifyingAndStillNotifiesAll() throws Exception {
+        sut.addObserver(fakeSleepingObserver(1, 20));
+        sut.addObserver(fakeSleepingObserver(2, 20));
+        sut.addObserver(fakeSleepingObserver(3, 20));
+
+        concurrentlyNotifyAndRemove(sut, 30);
+
+        assertEquals(3, notifications.size());
+
+        logs.forEach(System.out::println);
+    }
+
+    private void concurrentlyNotifyAndRemove(Impl sut, int millisBeforeRemove) throws InterruptedException {
+        ExecutorService exec = Executors.newFixedThreadPool(5);
+        List<Callable<Integer>> tasks = new ArrayList<>();
+        tasks.add(() -> {
+            var ctr = counter.getAndIncrement();
+            logs.add(
+                    "[" + Thread.currentThread().getName() + "-"
+                    + ctr + "] start removing observers..."
+            );
+            sleepOrFail(millisBeforeRemove, "observer removal", ctr);
+
+            logs.add(
+                    "[" + Thread.currentThread().getName() + "-"
+                    + ctr + "] - sut.removeObservers() entering..."
+            );
+            sut.removeObservers();
+            logs.add(
+                    "[" + Thread.currentThread().getName() + "-"
+                    + ctr + "] - sut.removeObservers() done."
+            );
+            logs.add(
+                    "[" + Thread.currentThread().getName() + "-"
+                    + ctr + "] observers removed."
+            );
+            return 0;
+        });
+        tasks.add(() -> {
+            sut.notifyObservers(fakeObservable);
+            return 0;
+        });
+        exec.invokeAll(tasks);
+
+        exec.shutdown();
+
+        if (!exec.awaitTermination(20, TimeUnit.SECONDS)) {
+            exec.shutdownNow();
+        }
+    }
+
+    private class Impl extends ObservableImpl {
+    }
+
+    private Observer fakeObserver(int index) {
+        return (Observable obs, Object argument) -> {
+            notifications.add(fakeNotification(index, argument));
+        };
+    }
+
+    private Observer fakeSleepingObserver(int index, int millis) {
+        return (Observable obs, Object argument) -> {
+            var ctr = counter.getAndIncrement();
+            logs.add(
+                    "[" + Thread.currentThread().getName()
+                    + "-" + ctr + "] start updating observer "
+                    + index + "..."
+            );
+            sleepOrFail(millis, "observer " + index + " update", ctr);
+            notifications.add(fakeNotification(index, argument));
+            logs.add(
+                    "[" + Thread.currentThread().getName()
+                    + "-" + ctr + "] observer "
+                    + index + " updated (slept for " + millis + " ms)."
+            );
+        };
+    }
+
+    private void sleepOrFail(int millis, String label, long ctr) {
+        try {
+            logs.add(
+                    "[" + Thread.currentThread().getName() + "-"
+                    + ctr + "] - " + label + ": sleeping for "
+                    + millis + " ms."
+            );
+            Thread.sleep(millis);
+            logs.add(
+                    "[" + Thread.currentThread().getName() + "-"
+                    + ctr + "] - " + label + ": woken up after "
+                    + millis + " ms."
+            );
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            fail("Unable to sleep");
+        }
+    }
+
+    private String fakeNotification(int index, Object argument) {
+        return "fo" + index + " - " + (argument != null ? argument.toString() : "null");
+    }
+
+    private final Observable fakeObservable = new Observable() {
+        @Override
+        public void addObserver(Observer observer) {
+        }
+
+        @Override
+        public void removeObserver(Observer observer) {
+        }
+
+        @Override
+        public void removeObservers() {
+        }
+
+        @Override
+        public void resetObservers() {
+        }
+    };
+}


### PR DESCRIPTION
The WeakHashMap capturing the registered observers is wrapped into a synchronized list, removing the need to synchronize the methods operating on it in `ObservableImpl`.

I created a rather elaborate test class before applying the changes.