### PR TITLE
fix: [#99] Ensure netbeans cache is discarded with platform.properties

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,6 @@ jobs:
         with:
           path: netbeans-plat
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('nbproject/platform.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/nbproject/platform.properties
+++ b/nbproject/platform.properties
@@ -2,6 +2,7 @@ branding.token=trgtd
 
 netbeans-plat-version=16
 
+
 suite.dir=${basedir}
 nbplatform.active.dir=${suite.dir}/netbeans-plat/${netbeans-plat-version}
 harness.dir=${nbplatform.active.dir}/harness

--- a/nbproject/platform.properties
+++ b/nbproject/platform.properties
@@ -2,7 +2,6 @@ branding.token=trgtd
 
 netbeans-plat-version=16
 
-
 suite.dir=${basedir}
 nbplatform.active.dir=${suite.dir}/netbeans-plat/${netbeans-plat-version}
 harness.dir=${nbplatform.active.dir}/harness


### PR DESCRIPTION
Fixes #99

I was applying a defunct restore key logic in the caching configuration. The idea is that for changes in `nbproject/platform.project` we discard the change.

The implementation so far would apply a fallback strategy that would reuse an older cache.

Fixing it here.

Note: The PR is expected to fail first, as the fix for #98 is not part of this branch. Hence the cache will be discarded and the configured set of netbeans modules (w/o `ide`) will be downloaded. This will fail, replicating the experience we had in fresh checkouts.

Once #98 is merged, we will merge main into this feature branch and expect  to see the build pass.

### Tasks

- [x] Ensure this PR fails
- [x] Merge PR #100 (from ticket #98) to `main` and merge `main` into this branch
- [x] Ensure this PR passes