### PR TITLE
replaced deprecated getUrl

### DIFF
--- a/modules/au.com.trgtd.tr.l10n.es_ES/src/au/com/trgtd/tr/l10n/es_ES/OverviewSVGProvider_es_ES.java
+++ b/modules/au.com.trgtd.tr.l10n.es_ES/src/au/com/trgtd/tr/l10n/es_ES/OverviewSVGProvider_es_ES.java
@@ -36,7 +36,7 @@ public class OverviewSVGProvider_es_ES implements OverviewSVGProvider {
     @Override
     public URL getURL() {
         try {
-            return FileUtil.getConfigFile("Overview/overview_es_ES.svg").getURL();
+            return FileUtil.getConfigFile("Overview/overview_es_ES.svg").toURL();
         } catch (Exception ex) {
             return null;
         }

--- a/modules/au.com.trgtd.tr.l10n.fr_FR/src/au/com/trgtd/tr/l10n/fr_FR/OverviewSVGProvider_fr_FR.java
+++ b/modules/au.com.trgtd.tr.l10n.fr_FR/src/au/com/trgtd/tr/l10n/fr_FR/OverviewSVGProvider_fr_FR.java
@@ -36,11 +36,7 @@ public class OverviewSVGProvider_fr_FR implements OverviewSVGProvider {
  
     @Override
     public URL getURL() {
-        try {
-            return FileUtil.getConfigFile("Overview/overview_fr_FR.svg").getURL();
-        } catch (FileStateInvalidException ex) {
-            return null;
-        }
+        return FileUtil.getConfigFile("Overview/overview_fr_FR.svg").toURL();
     }
  
 }

--- a/modules/au.com.trgtd.tr.resource/src/au/com/trgtd/tr/resource/Resource.java
+++ b/modules/au.com.trgtd.tr.resource/src/au/com/trgtd/tr/resource/Resource.java
@@ -136,12 +136,7 @@ public class Resource {
     public final static String Overview = PATH + "Overview.png";
 
     public final static URL getOverviewURL() {
-        try {
-            return FileUtil.getConfigFile("Overview/overview.svg").getURL();
-        } catch (FileStateInvalidException ex) {
-            Exceptions.printStackTrace(ex);
-            return null;
-        }
+        return FileUtil.getConfigFile("Overview/overview.svg").toURL();
     }
 
 }


### PR DESCRIPTION
Fixed warning: [deprecation] getURL() in FileObject has been deprecated

Replaced deprecated method by suggestion from documentation - https://bits.netbeans.org/dev/javadoc/org-openide-filesystems/org/openide/filesystems/FileObject.html#getURL--