### PR TITLE
refactor: DiamondOperator

### DIFF
--- a/modules/au.com.trgtd.tr.appl/src/au/com/trgtd/tr/appl/prefs/ApplicationPanel.java
+++ b/modules/au.com.trgtd.tr.appl/src/au/com/trgtd/tr/appl/prefs/ApplicationPanel.java
@@ -91,7 +91,7 @@ final class ApplicationPanel extends javax.swing.JPanel {
                 versionCheckCombo.setSelectedIndex(ApplicationPrefs.VERSION_CHECK_PERIOD_NEVER);
             }
         });
-        versionCheckCombo = new JComboBox(new DefaultComboBoxModel(PERIODS));
+        versionCheckCombo = new JComboBox<>(new DefaultComboBoxModel<>(PERIODS));
         versionCheckCombo.setMaximumRowCount(PERIODS.length);
         idleCheckBox = new JCheckBox(msg("prefs.inactive.quit.label"));
         idleCheckBox.setHorizontalTextPosition(SwingConstants.TRAILING);

--- a/modules/au.com.trgtd.tr.calendar.ical4j.impl/src/au/com/trgtd/tr/calendar/ical4j/impl/prefs/OptionsPanel.java
+++ b/modules/au.com.trgtd.tr.calendar.ical4j.impl/src/au/com/trgtd/tr/calendar/ical4j/impl/prefs/OptionsPanel.java
@@ -92,7 +92,7 @@ public class OptionsPanel extends JPanel implements CalendarSynchronizerOptions 
 
     public void load() {
         initTimeZoneItems();
-        timezoneCombo.setModel(new DefaultComboBoxModel(tzlist));
+        timezoneCombo.setModel(new DefaultComboBoxModel<>(tzlist));
         timezoneCombo.setMaximumRowCount(Constants.COMBO_MAX_ROWS);
         timezoneCombo.setSelectedItem(Options.getTimeZoneID());
         folderField.setText(Options.getICalendarPath());

--- a/modules/au.com.trgtd.tr.datastore.xstream/src/au/com/trgtd/tr/datastore/xstream/BackupThread.java
+++ b/modules/au.com.trgtd.tr.datastore.xstream/src/au/com/trgtd/tr/datastore/xstream/BackupThread.java
@@ -140,7 +140,7 @@ public class BackupThread extends Thread {
         FileFilter filter = (File file) -> file.isFile()
                 && file.getName().toLowerCase().matches(regex);
 
-        List<File> recoveryFiles = new ArrayList();
+        List<File> recoveryFiles = new ArrayList<>();
         Collections.addAll(recoveryFiles, dir.listFiles(filter));
         
         if (!recoveryFiles.isEmpty()) {

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
@@ -796,7 +796,7 @@ public class Pop3 {
          * @return Vector        Retourne un Vector contenant les chemin complet des fichiers
          */
         public static Vector getFile(Message pop_message) throws Exception {
-            Vector vec = new Vector();
+            Vector vec = new Vector<>();
             Object content = pop_message.getContent();
             if (content instanceof Multipart mp) {
                 vec = getFileHandleMultipart(mp);
@@ -838,7 +838,7 @@ public class Pop3 {
          * @return Vector                Retourne un Vector contenant les chemin complet des fichiers
          */
         public static Vector getFileEmbed(Message pop_message, String _contentType) throws Exception {
-            Vector vec = new Vector();
+            Vector vec = new Vector<>();
             Object content = pop_message.getContent();
             if (content instanceof Multipart mp) {
                 vec = getFileHandleMultipart(mp, _contentType);

--- a/modules/au.com.trgtd.tr.extract.clean/src/au/com/trgtd/tr/extract/clean/ExtractCleanPanel.java
+++ b/modules/au.com.trgtd.tr.extract.clean/src/au/com/trgtd/tr/extract/clean/ExtractCleanPanel.java
@@ -41,11 +41,11 @@ final class ExtractCleanPanel extends javax.swing.JPanel {
     private JComponent getView() {
         runLabel = new JLabel(getMsg("Run_Label"));
         ageLabel = new JLabel(getMsg("Age_Label"));
-        runCombo = new TRComboBox(new DefaultComboBoxModel(intervals));
+        runCombo = new TRComboBox<>(new DefaultComboBoxModel<>(intervals));
         runCombo.addActionListener((java.awt.event.ActionEvent evt) -> {
             controller.changed();
         });
-        ageCombo = new TRComboBox(new DefaultComboBoxModel(ages));
+        ageCombo = new TRComboBox<>(new DefaultComboBoxModel<>(ages));
         ageCombo.addActionListener((java.awt.event.ActionEvent evt) -> {
             controller.changed();
         });

--- a/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/prefs/ExtractPanel.java
+++ b/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/prefs/ExtractPanel.java
@@ -98,7 +98,7 @@ final class ExtractPanel extends JPanel {
         Vector<String> encodings = new Vector<>();
         encodings.add("");
         encodings.addAll(Charset.availableCharsets().keySet());
-        return new DefaultComboBoxModel(encodings);
+        return new DefaultComboBoxModel<>(encodings);
     }
 
     void load() {

--- a/modules/au.com.trgtd.tr.find/src/au/com/trgtd/tr/find/ui/FoundItems.java
+++ b/modules/au.com.trgtd.tr.find/src/au/com/trgtd/tr/find/ui/FoundItems.java
@@ -60,7 +60,7 @@ public class FoundItems implements Observable {
 
     public List<FoundItem> getItems() {
         synchronized(this) {
-            return Collections.unmodifiableList(new ArrayList(list));
+            return Collections.unmodifiableList(new ArrayList<>(list));
         }
     }
 

--- a/modules/au.com.trgtd.tr.imports.thoughts/src/au/com/trgtd/tr/imports/thoughts/prefs/ImportThoughtsPrefsPanel.java
+++ b/modules/au.com.trgtd.tr.imports.thoughts/src/au/com/trgtd/tr/imports/thoughts/prefs/ImportThoughtsPrefsPanel.java
@@ -63,7 +63,7 @@ final class ImportThoughtsPrefsPanel extends JPanel {
         Vector<String> encodings = new Vector<>();
         encodings.add("");
         encodings.addAll(Charset.availableCharsets().keySet());
-        return new DefaultComboBoxModel(encodings);
+        return new DefaultComboBoxModel<>(encodings);
     }
 
     void load() {

--- a/modules/au.com.trgtd.tr.prefs.actions/src/au/com/trgtd/tr/prefs/actions/ActionPrefsPanel.java
+++ b/modules/au.com.trgtd.tr.prefs.actions/src/au/com/trgtd/tr/prefs/actions/ActionPrefsPanel.java
@@ -106,7 +106,7 @@ final class ActionPrefsPanel extends JPanel {
         states.add(ActionPrefs.ActionState.DOASAP);
         states.add(ActionPrefs.ActionState.SCHEDULED);
         states.add(ActionPrefs.ActionState.DELEGATED);
-        actionStatesCombo = new TRComboBox(new DefaultComboBoxModel(states));
+        actionStatesCombo = new TRComboBox(new DefaultComboBoxModel<>(states));
         actionStatesCombo.setMaximumRowCount(states.size());
         schdTimeLabel = new TRLabel(getMsg("CTL_DefSchdTime"));
         schdTimeHrSpinner = new HourSpinner();
@@ -155,7 +155,7 @@ final class ActionPrefsPanel extends JPanel {
         Vector<String> encodings = new Vector<>();
         encodings.add("");
         encodings.addAll(Charset.availableCharsets().keySet());
-        return new DefaultComboBoxModel(encodings);
+        return new DefaultComboBoxModel<>(encodings);
     }
 
     private boolean isValidEncoding() {

--- a/modules/au.com.trgtd.tr.prefs.dates/src/au/com/trgtd/tr/prefs/dates/DatesOptionsPanel.java
+++ b/modules/au.com.trgtd.tr.prefs.dates/src/au/com/trgtd/tr/prefs/dates/DatesOptionsPanel.java
@@ -46,13 +46,13 @@ final class DatesOptionsPanel extends JPanel {
 
     private JComponent getView() {
         dayLabel = new JLabel(getMsg("Dates.FirstDayOfWeek"));
-        dayCombo = new JComboBox();
+        dayCombo = new JComboBox<>();
         dayCombo.addActionListener((java.awt.event.ActionEvent evt) -> {
             controller.changed();
         });
         
         orderLabel = new JLabel(getMsg("Dates.Order"));
-        orderCombo = new JComboBox();
+        orderCombo = new JComboBox<>();
         orderCombo.addActionListener((java.awt.event.ActionEvent evt) -> {
             controller.changed();
         });
@@ -86,12 +86,12 @@ final class DatesOptionsPanel extends JPanel {
 
     private void doLoad() {
         initDayItems();
-        dayCombo.setModel(new DefaultComboBoxModel(days));
+        dayCombo.setModel(new DefaultComboBoxModel<>(days));
         dayCombo.setMaximumRowCount(days.size());
         dayCombo.setSelectedItem(getDayItem(DatesPrefs.getFirstDayOfWeek()));
 
         initOrderItems();
-        orderCombo.setModel(new DefaultComboBoxModel(orders));
+        orderCombo.setModel(new DefaultComboBoxModel<>(orders));
         orderCombo.setMaximumRowCount(orders.size());
         orderCombo.setSelectedItem(getOrderItem(DatesPrefs.getDateOrder()));
     }

--- a/modules/au.com.trgtd.tr.prefs.projects/src/au/com/trgtd/tr/prefs/projects/ProjectsOptionsPanel.java
+++ b/modules/au.com.trgtd.tr.prefs.projects/src/au/com/trgtd/tr/prefs/projects/ProjectsOptionsPanel.java
@@ -95,7 +95,7 @@ final class ProjectsOptionsPanel extends JPanel {
         actionStatesCombo = new TRComboBox(new DefaultComboBoxModel(states.toArray()));
         actionStatesCombo.setMaximumRowCount(states.size());
         printFormatLabel = new JLabel(getMsg("print.format.Label"));
-        printFormatCombo = new JComboBox(new PageSizeChoice[] { PageSizeChoice.Prompt, PageSizeChoice.A4, PageSizeChoice.Letter });
+        printFormatCombo = new JComboBox<>(new PageSizeChoice[] { PageSizeChoice.Prompt, PageSizeChoice.A4, PageSizeChoice.Letter });
 
         JPanel panel = new JPanel(new MigLayout("", "0[]2[grow]0", "0[]2[]2[]2[]2[]2[]0"));
 

--- a/modules/au.com.trgtd.tr.prefs.ui/src/au/com/trgtd/tr/prefs/ui/GUIOptionsPanel.java
+++ b/modules/au.com.trgtd.tr.prefs.ui/src/au/com/trgtd/tr/prefs/ui/GUIOptionsPanel.java
@@ -50,14 +50,14 @@ final class GUIOptionsPanel extends JPanel {
     private JComponent getView() {
         initActions();
         initialActionLabel = new JLabel(getMsg("LBL_InitialWindow"));
-        initialActionCombo = new JComboBox(new DefaultComboBoxModel(actions));
+        initialActionCombo = new JComboBox<>(new DefaultComboBoxModel<>(actions));
         initialActionCombo.setMaximumRowCount(actions.size());
         initialActionCombo.addActionListener((ActionEvent evt) -> {
             controller.changed();
         });
         initPositions();
         buttonsPositionLabel = new JLabel(getMsg("LBL_ButtonsPosition"));
-        buttonsPositionCombo = new JComboBox(new DefaultComboBoxModel(positions));
+        buttonsPositionCombo = new JComboBox<>(new DefaultComboBoxModel<>(positions));
         buttonsPositionCombo.setMaximumRowCount(positions.size());
         buttonsPositionCombo.addActionListener((ActionEvent evt) -> {
             controller.changed();

--- a/modules/au.com.trgtd.tr.swing/src/au/com/trgtd/tr/swing/date/combo/DateCombo.java
+++ b/modules/au.com.trgtd.tr.swing/src/au/com/trgtd/tr/swing/date/combo/DateCombo.java
@@ -55,7 +55,7 @@ public class DateCombo extends TRComboBox implements ActionListener {
      * option the selected date is set in the first item and it is selected.
      */
     public DateCombo(Window window, DateItem[] items, boolean calc, DateFormat df) {
-        super(new DefaultComboBoxModel(items));
+        super(new DefaultComboBoxModel<>(items));
         this.calc = calc;
         this.df = df;
         if (window instanceof Frame frame) {

--- a/modules/au.com.trgtd.tr.view.actn/src/au/com/trgtd/tr/view/actn/ActionPanel.java
+++ b/modules/au.com.trgtd.tr.view.actn/src/au/com/trgtd/tr/view/actn/ActionPanel.java
@@ -1671,10 +1671,7 @@ if (ass.getDate() == null) {
     private PropertyChangeListener propertyListenerDoneDate;
     private PropertyChangeListener propertyListenerScheduledDate;
     
-    
     private PropertyChangeListener propertyListenerDelegate;
-    
-    
     
     private Observer criteriaObserver;
     private PreferenceChangeListener prefsChangeListener;

--- a/modules/au.com.trgtd.tr.view.actn/src/au/com/trgtd/tr/view/actn/PeriodMonthlyPanel.java
+++ b/modules/au.com.trgtd.tr.view.actn/src/au/com/trgtd/tr/view/actn/PeriodMonthlyPanel.java
@@ -61,11 +61,11 @@ public class PeriodMonthlyPanel extends JPanel {
     }
     
     private ComboBoxModel getDayComboModel() {
-        return new DefaultComboBoxModel(PeriodMonth.OnTheDay.values());
+        return new DefaultComboBoxModel<>(PeriodMonth.OnTheDay.values());
     }
 
     private ComboBoxModel getNthComboModel() {
-        return new DefaultComboBoxModel(PeriodMonth.OnTheNth.values());
+        return new DefaultComboBoxModel<>(PeriodMonth.OnTheNth.values());
     }
 
     /**

--- a/modules/au.com.trgtd.tr.view.actn/src/au/com/trgtd/tr/view/actn/PeriodYearlyPanel.java
+++ b/modules/au.com.trgtd.tr.view.actn/src/au/com/trgtd/tr/view/actn/PeriodYearlyPanel.java
@@ -57,11 +57,11 @@ public class PeriodYearlyPanel extends JPanel {
     }
 
     private ComboBoxModel getDayComboModel() {
-        return new DefaultComboBoxModel(PeriodMonth.OnTheDay.values());
+        return new DefaultComboBoxModel<>(PeriodMonth.OnTheDay.values());
     }
 
     private ComboBoxModel getNthComboModel() {
-        return new DefaultComboBoxModel(PeriodMonth.OnTheNth.values());
+        return new DefaultComboBoxModel<>(PeriodMonth.OnTheNth.values());
     }
 
     private String getSelectedMonthsText() {

--- a/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/prefs/ActionsPrefsPanel.java
+++ b/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/prefs/ActionsPrefsPanel.java
@@ -48,7 +48,7 @@ final class ActionsPrefsPanel extends JPanel {
         colourCheck.setSelected(ActionsPrefs.isReportUseColour());
         strikeCheck.setSelected(ActionsPrefs.isReportStrikeDone());
         items = (Vector<Item>) (new ParamFont(null, null)).getItems();
-        fontCombo.setModel(new DefaultComboBoxModel(items));
+        fontCombo.setModel(new DefaultComboBoxModel<>(items));
         String font = ActionsPrefs.getReportFont();
         for (Item item : items) {
             if (item.value.equals(font)) {

--- a/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/ReviewActionsPanel.java
+++ b/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/ReviewActionsPanel.java
@@ -123,7 +123,7 @@ public class ReviewActionsPanel extends JPanel implements ListSelectionListener,
 
         actionsEventList = new BasicEventList<>();
         actionsEventList.addAll(actionsList);
-        actionsFilterList = new FilterList(actionsEventList, filters.getMatcherEditor());
+        actionsFilterList = new FilterList<>(actionsEventList, filters.getMatcherEditor());
         actionsFilterList.addListEventListener((ListEvent<Action> e) -> {
             itemCountShower.showItemCount(e.getSourceList().size());
             // fix problem of number of selected rows increasing by clearing
@@ -191,7 +191,7 @@ public class ReviewActionsPanel extends JPanel implements ListSelectionListener,
 
         actionsTable.setDefaultRenderer(StyledString.class, new StyledStringRenderer());
 
-        tableSorter = new TableComparatorChooser(actionsTable, actionsSortedList, true);
+        tableSorter = new TableComparatorChooser<>(actionsTable, actionsSortedList, true);
 
         actionsTable.addKeyListener(new KeyAdapter() {
             @Override

--- a/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/ReviewActionsTableFormat.java
+++ b/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/ReviewActionsTableFormat.java
@@ -443,5 +443,4 @@ public class ReviewActionsTableFormat implements AdvancedTableFormat, WritableTa
 //                
         return null;
     }
-    
 }

--- a/modules/au.com.trgtd.tr.view.criteria/src/au/com/trgtd/tr/view/criteria/screen/EnergyNode.java
+++ b/modules/au.com.trgtd.tr.view.criteria/src/au/com/trgtd/tr/view/criteria/screen/EnergyNode.java
@@ -176,7 +176,7 @@ final class EnergyNode extends AbstractNode implements EditCookie, Observer {
     }
 
     private JComboBox getReplacementCombo(Data data) {
-        JComboBox cb = new JComboBox();
+        JComboBox cb = new JComboBox<>();
         cb.addItem(new NullItem());
         for (Value itemValue : data.getEnergyCriterion().values.list()) {
             if (!itemValue.equals(value)) {

--- a/modules/au.com.trgtd.tr.view.criteria/src/au/com/trgtd/tr/view/criteria/screen/PriorityNode.java
+++ b/modules/au.com.trgtd.tr.view.criteria/src/au/com/trgtd/tr/view/criteria/screen/PriorityNode.java
@@ -168,7 +168,7 @@ final class PriorityNode extends AbstractNode implements EditCookie, Observer {
     }
 
     private JComboBox getReplacementCombo(Data data) {
-        JComboBox cb = new JComboBox();
+        JComboBox cb = new JComboBox<>();
         cb.addItem(new NullItem());
         for (Value itemValue : data.getPriorityCriterion().values.list()) {
             if (!itemValue.equals(value)) {

--- a/modules/au.com.trgtd.tr.view.criteria/src/au/com/trgtd/tr/view/criteria/screen/TimeNode.java
+++ b/modules/au.com.trgtd.tr.view.criteria/src/au/com/trgtd/tr/view/criteria/screen/TimeNode.java
@@ -120,7 +120,7 @@ final class TimeNode extends AbstractNode implements EditCookie, Observer {
     }
 
     private JComboBox getReplacementCombo(Data data) {
-        JComboBox cb = new JComboBox();
+        JComboBox cb = new JComboBox<>();
         cb.addItem(new NullItem());
         for (Value itemValue : data.getTimeCriterion().values.list()) {
             if (!itemValue.equals(value)) {

--- a/modules/au.com.trgtd.tr.view.goals/src/au/com/trgtd/tr/view/goals/GoalChildren.java
+++ b/modules/au.com.trgtd.tr.view.goals/src/au/com/trgtd/tr/view/goals/GoalChildren.java
@@ -49,7 +49,7 @@ public class GoalChildren extends Children.Keys<Object> implements PropertyChang
         assert (goalCtrl != null);
         this.view = view;
         this.goalCtrl = goalCtrl;
-        this.keys = new ArrayList();
+        this.keys = new ArrayList<>();
     }
 
     @Override

--- a/modules/au.com.trgtd.tr.view.goals/src/au/com/trgtd/tr/view/goals/levels/combo/LevelsComboBoxModel.java
+++ b/modules/au.com.trgtd.tr.view.goals/src/au/com/trgtd/tr/view/goals/levels/combo/LevelsComboBoxModel.java
@@ -18,11 +18,9 @@
 package au.com.trgtd.tr.view.goals.levels.combo;
 
 import java.beans.PropertyChangeEvent;
-import java.util.List;
-
-import javax.swing.DefaultComboBoxModel;
-
 import java.beans.PropertyChangeListener;
+import java.util.List;
+import javax.swing.DefaultComboBoxModel;
 import tr.model.goals.ctrl.LevelCtrl;
 import tr.model.goals.ctrl.LevelsCtrl;
 import tr.model.goals.ctrl.LevelsCtrlLookup;

--- a/modules/au.com.trgtd.tr.view.process/src/au/com/trgtd/tr/view/process/ProcessPanel.java
+++ b/modules/au.com.trgtd.tr.view.process/src/au/com/trgtd/tr/view/process/ProcessPanel.java
@@ -1851,7 +1851,7 @@ public final class ProcessPanel extends JPanel implements Observer, ProcessCooki
                 return new CriterionComboBoxModel(criterion);
             }
         }
-        return new DefaultComboBoxModel();
+        return new DefaultComboBoxModel<>();
     }
 
     private ComboBoxModel getEnergyComboBoxModel() {
@@ -1861,7 +1861,7 @@ public final class ProcessPanel extends JPanel implements Observer, ProcessCooki
                 return new CriterionComboBoxModel(criterion);
             }
         }
-        return new DefaultComboBoxModel();
+        return new DefaultComboBoxModel<>();
     }
 
     private ComboBoxModel getPriorityComboBoxModel() {
@@ -1871,7 +1871,7 @@ public final class ProcessPanel extends JPanel implements Observer, ProcessCooki
                 return new CriterionComboBoxModel(criterion);
             }
         }
-        return new DefaultComboBoxModel();
+        return new DefaultComboBoxModel<>();
     }
 
     private void recurrenceButtonActionPerformed(ActionEvent e) {

--- a/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/screen/ReferencesPanel.java
+++ b/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/screen/ReferencesPanel.java
@@ -129,7 +129,7 @@ public class ReferencesPanel extends JPanel implements ListSelectionListener, Ob
         refsTable.setDefaultRenderer(Topic.class,
                 new ReferencesTableFormat.TopicRenderer());
         
-        tableSorter = new TableComparatorChooser(refsTable, refsSortedList, true);
+        tableSorter = new TableComparatorChooser<>(refsTable, refsSortedList, true);
         
         refsTable.addKeyListener(new KeyAdapter() {
             @Override

--- a/modules/au.com.trgtd.tr.view.someday/src/au/com/trgtd/tr/view/someday/screen/SomedaysPanel.java
+++ b/modules/au.com.trgtd.tr.view.someday/src/au/com/trgtd/tr/view/someday/screen/SomedaysPanel.java
@@ -87,7 +87,7 @@ public class SomedaysPanel extends JPanel implements ListSelectionListener, Obse
         refsEventList = new BasicEventList<>();
         refsEventList.addAll(refsList);
         
-        FilterList refsFilterList = new FilterList(refsEventList, refsMatcherEditor);
+        FilterList refsFilterList = new FilterList<>(refsEventList, refsMatcherEditor);
         
         data.getFutureManager().addObserver(this);
         
@@ -133,7 +133,7 @@ public class SomedaysPanel extends JPanel implements ListSelectionListener, Obse
         futuresTable.setDefaultRenderer(Topic.class,
                 new SomedaysTableFormat.TopicRenderer());
         
-        tableSorter = new TableComparatorChooser(futuresTable, refsSortedList, true);
+        tableSorter = new TableComparatorChooser<>(futuresTable, refsSortedList, true);
         
         futuresTable.addKeyListener(new KeyAdapter() {
             @Override

--- a/modules/au.com.trgtd.tr.view/src/au/com/trgtd/tr/view/CriteriaChangePanel.java
+++ b/modules/au.com.trgtd.tr.view/src/au/com/trgtd/tr/view/CriteriaChangePanel.java
@@ -63,9 +63,9 @@ public class CriteriaChangePanel extends JPanel {
         });
 
         valueLabel = new JLabel(getMsg("CTL_Value"));
-        priorities = new DefaultComboBoxModel(data.getPriorityCriterion().values.list());
-        times = new DefaultComboBoxModel(data.getTimeCriterion().values.list());
-        energies = new DefaultComboBoxModel(data.getEnergyCriterion().values.list());
+        priorities = new DefaultComboBoxModel<>(data.getPriorityCriterion().values.list());
+        times = new DefaultComboBoxModel<>(data.getTimeCriterion().values.list());
+        energies = new DefaultComboBoxModel<>(data.getEnergyCriterion().values.list());
         valueCombo = new TRComboBox(priorities);
  
         setLayout(new MigLayout("insets 12px", "2[]2[]4[]2[200]2", "2[]2"));

--- a/modules/tr.model/src/tr/model/project/Project.java
+++ b/modules/tr.model/src/tr/model/project/Project.java
@@ -1028,7 +1028,7 @@ public class Project extends ObservableImpl
             return;
         }
         synchronized (this) {
-            Vector reorderedChildren = new Vector(children);
+            Vector reorderedChildren = new Vector<>(children);
             for (int i = 0; i < srcItems.length; i++) {
                 if (contains(srcItems[i]) && contains(dstItems[i])) {
                     int dstIndex = children.indexOf(dstItems[i]);

--- a/modules/tr.model/src/tr/model/util/Manager.java
+++ b/modules/tr.model/src/tr/model/util/Manager.java
@@ -101,7 +101,7 @@ public class Manager<T extends Observable> extends ObservableImpl implements Obs
         
         item.addObserver(this);
         
-        notifyObservers(this, new EventAdd(item));
+        notifyObservers(this, new EventAdd<>(item));
         
         return true;
     }
@@ -122,7 +122,7 @@ public class Manager<T extends Observable> extends ObservableImpl implements Obs
         
         item.addObserver(this);
         
-        notifyObservers(this, new EventInsert(item, pos));
+        notifyObservers(this, new EventInsert<>(item, pos));
     }
     
     /**
@@ -145,7 +145,7 @@ public class Manager<T extends Observable> extends ObservableImpl implements Obs
         
         item.removeObserver(this);
         
-        notifyObservers(this, new EventRemove(item));
+        notifyObservers(this, new EventRemove<>(item));
         
         return true;
     }
@@ -196,7 +196,7 @@ public class Manager<T extends Observable> extends ObservableImpl implements Obs
             item.addObserver(this);
         }
         
-        notifyObservers(this, new EventReplace(old, item, index));
+        notifyObservers(this, new EventReplace<>(old, item, index));
     }
     
     /**


### PR DESCRIPTION
This is the first of a series of 4 PRs, each resolving part of the warnings in NetBeans.

This first one introduces the Diamond Operator when instantiating classes that do use Generics but we don't use it yet.

Next to introducing the Diamond `<>`, the PR also fixes a small number of
- whitespace issues
- organize import s

It is most likely advisable to set the review mode to "unified" (instead of "split").