### PR TITLE
refactor: Use Generics where available

### DIFF
--- a/modules/au.com.trgtd.tr.appl/src/au/com/trgtd/tr/appl/prefs/ApplicationPanel.java
+++ b/modules/au.com.trgtd.tr.appl/src/au/com/trgtd/tr/appl/prefs/ApplicationPanel.java
@@ -130,7 +130,7 @@ final class ApplicationPanel extends javax.swing.JPanel {
     }
 
     private JCheckBox versionCheckBox;
-    private JComboBox versionCheckCombo;
+    private JComboBox<String> versionCheckCombo;
     private JCheckBox idleCheckBox;
     private JLabel inactiveHrsLabel;
     private JLabel inactiveMinsLabel;

--- a/modules/au.com.trgtd.tr.calendar.ical4j.impl/src/au/com/trgtd/tr/calendar/ical4j/impl/prefs/OptionsPanel.java
+++ b/modules/au.com.trgtd.tr.calendar.ical4j.impl/src/au/com/trgtd/tr/calendar/ical4j/impl/prefs/OptionsPanel.java
@@ -174,7 +174,7 @@ public class OptionsPanel extends JPanel implements CalendarSynchronizerOptions 
     private JButton folderButton;
     private JLabel folderLabel;
     private JTextField folderField;
-    private JComboBox timezoneCombo;
+    private JComboBox<String> timezoneCombo;
     private JLabel timezoneLabel;
 
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents

--- a/modules/au.com.trgtd.tr.calendar/src/au/com/trgtd/tr/calendar/prefs/CalendarPrefsPanel.java
+++ b/modules/au.com.trgtd.tr.calendar/src/au/com/trgtd/tr/calendar/prefs/CalendarPrefsPanel.java
@@ -260,7 +260,7 @@ final class CalendarPrefsPanel extends javax.swing.JPanel {
                 selected = item;
             }
         }
-        synchronizerCombo.setModel(new DefaultComboBoxModel(synchronizers.toArray()));
+        synchronizerCombo.setModel(new DefaultComboBoxModel<>(synchronizers.toArray(SynchronizerItem[]::new)));
         if (selected == null) {
             loadSynchronizerOptions(null);
         } else {
@@ -430,7 +430,7 @@ final class CalendarPrefsPanel extends javax.swing.JPanel {
     private JCheckBox syncFutureProjectsCheck;
     private JCheckBox syncFutureProjectsSepCheck;
 
-    private JComboBox synchronizerCombo;
+    private JComboBox<SynchronizerItem> synchronizerCombo;
     private JLabel synchronizerLabel;
     private JPanel synchronizerPanel;
     private JScrollPane synchronizerScrollPane;

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
@@ -795,8 +795,8 @@ public class Pop3 {
          *
          * @return Vector        Retourne un Vector contenant les chemin complet des fichiers
          */
-        public static Vector getFile(Message pop_message) throws Exception {
-            Vector vec = new Vector<>();
+        public static Vector<String> getFile(Message pop_message) throws Exception {
+            Vector<String> vec = new Vector<>();
             Object content = pop_message.getContent();
             if (content instanceof Multipart mp) {
                 vec = getFileHandleMultipart(mp);
@@ -837,8 +837,8 @@ public class Pop3 {
          *
          * @return Vector                Retourne un Vector contenant les chemin complet des fichiers
          */
-        public static Vector getFileEmbed(Message pop_message, String _contentType) throws Exception {
-            Vector vec = new Vector<>();
+        public static Vector<String> getFileEmbed(Message pop_message, String _contentType) throws Exception {
+            Vector<String> vec = new Vector<>();
             Object content = pop_message.getContent();
             if (content instanceof Multipart mp) {
                 vec = getFileHandleMultipart(mp, _contentType);

--- a/modules/au.com.trgtd.tr.extract.clean/src/au/com/trgtd/tr/extract/clean/ExtractCleanPanel.java
+++ b/modules/au.com.trgtd.tr.extract.clean/src/au/com/trgtd/tr/extract/clean/ExtractCleanPanel.java
@@ -141,9 +141,9 @@ final class ExtractCleanPanel extends javax.swing.JPanel {
         return NbBundle.getMessage(getClass(), key);
     }
 
-    private javax.swing.JComboBox ageCombo;
+    private javax.swing.JComboBox<Item> ageCombo;
     private javax.swing.JLabel ageLabel;
-    private javax.swing.JComboBox runCombo;
+    private javax.swing.JComboBox<Item> runCombo;
     private javax.swing.JLabel runLabel;
 
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents

--- a/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ParamsDialog.java
+++ b/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/ParamsDialog.java
@@ -102,7 +102,7 @@ public class ParamsDialog extends JDialog {
             } else if (param.type == Param.Type.COMBOBOX) {
                 List<Item> items = param.getItems();
                 if (items != null && !items.isEmpty()) {
-                    JComboBox combo = new TRComboBox(items.toArray());
+                    JComboBox<Item> combo = new TRComboBox<>(items.toArray(Item[]::new));
                     combo.setPreferredSize(COMBOBOX_SIZE);
                     if (param.getValue() != null && !param.getValue().trim().equals("")) {
                         // set selected item

--- a/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/prefs/ExtractPanel.java
+++ b/modules/au.com.trgtd.tr.extract/src/au/com/trgtd/tr/extract/prefs/ExtractPanel.java
@@ -94,7 +94,7 @@ final class ExtractPanel extends JPanel {
         }
     }
 
-    private ComboBoxModel getEncodingModel() {
+    private ComboBoxModel<String> getEncodingModel() {
         Vector<String> encodings = new Vector<>();
         encodings.add("");
         encodings.addAll(Charset.availableCharsets().keySet());
@@ -168,7 +168,7 @@ final class ExtractPanel extends JPanel {
         return NbBundle.getMessage(ExtractPanel.class, key);
     }
 
-    private javax.swing.JComboBox encodingCombo;
+    private javax.swing.JComboBox<String> encodingCombo;
     private javax.swing.JLabel encodingLabel;
     private javax.swing.JButton browseButton;
     private javax.swing.JLabel folderLabel;

--- a/modules/au.com.trgtd.tr.imports.thoughts/src/au/com/trgtd/tr/imports/thoughts/prefs/ImportThoughtsPrefsPanel.java
+++ b/modules/au.com.trgtd.tr.imports.thoughts/src/au/com/trgtd/tr/imports/thoughts/prefs/ImportThoughtsPrefsPanel.java
@@ -59,7 +59,7 @@ final class ImportThoughtsPrefsPanel extends JPanel {
         return NbBundle.getMessage(getClass(), key);
     }
 
-    private ComboBoxModel getEncodingModel() {
+    private ComboBoxModel<String> getEncodingModel() {
         Vector<String> encodings = new Vector<>();
         encodings.add("");
         encodings.addAll(Charset.availableCharsets().keySet());
@@ -90,7 +90,7 @@ final class ImportThoughtsPrefsPanel extends JPanel {
         return encoding == null ? "" : encoding;
     }
 
-    private JComboBox encodingCombo;
+    private JComboBox<String> encodingCombo;
     private JLabel encodingLabel;
 
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents

--- a/modules/au.com.trgtd.tr.prefs.actions/src/au/com/trgtd/tr/prefs/actions/ActionPrefsPanel.java
+++ b/modules/au.com.trgtd.tr.prefs.actions/src/au/com/trgtd/tr/prefs/actions/ActionPrefsPanel.java
@@ -151,7 +151,7 @@ final class ActionPrefsPanel extends JPanel {
         add(schdDurMnsSpinner,      "align left, wrap");
     }
 
-    private ComboBoxModel getEncodingModel() {
+    private ComboBoxModel<String> getEncodingModel() {
         Vector<String> encodings = new Vector<>();
         encodings.add("");
         encodings.addAll(Charset.availableCharsets().keySet());
@@ -188,10 +188,10 @@ final class ActionPrefsPanel extends JPanel {
     private JCheckBox startDateCheckBox;
     private JCheckBox editCreateDateCheckBox;
     private JCheckBox noteEmailCheckBox;
-    private JComboBox encodingCombo;
+    private JComboBox<String> encodingCombo;
     private JLabel encodingLabel;
     private JLabel actionStatesLabel;
-    private JComboBox actionStatesCombo;
+    private JComboBox<ActionPrefs.ActionState> actionStatesCombo;
     private Vector<ActionPrefs.ActionState> states;
 
     private JLabel delegateModeLabel;

--- a/modules/au.com.trgtd.tr.prefs.data/src/au/com/trgtd/tr/prefs/data/DataPrefsPanel.java
+++ b/modules/au.com.trgtd.tr.prefs.data/src/au/com/trgtd/tr/prefs/data/DataPrefsPanel.java
@@ -313,7 +313,7 @@ final class DataPrefsPanel extends JPanel implements ChangeListener {
     private JRadioButton recoveryKeepNbrRadio;
     private JSpinner recoveryKeepNbrSpinner;
     private JLabel backupLabel;
-    private JComboBox backupCombo;
+    private JComboBox<Item> backupCombo;
     private JLabel backupFolderLabel;
     private JTextField backupFolderText;
     private JButton backupBrowseButton;

--- a/modules/au.com.trgtd.tr.prefs.dates/src/au/com/trgtd/tr/prefs/dates/DatesOptionsPanel.java
+++ b/modules/au.com.trgtd.tr.prefs.dates/src/au/com/trgtd/tr/prefs/dates/DatesOptionsPanel.java
@@ -163,9 +163,9 @@ final class DatesOptionsPanel extends JPanel {
         return orders.get(0);
     }
 
-    private JComboBox dayCombo;
+    private JComboBox<ComboItem> dayCombo;
     private JLabel dayLabel;
-    private JComboBox orderCombo;
+    private JComboBox<ComboItem> orderCombo;
     private JLabel orderLabel;
 
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents

--- a/modules/au.com.trgtd.tr.prefs.projects/src/au/com/trgtd/tr/prefs/projects/ProjectsOptionsPanel.java
+++ b/modules/au.com.trgtd.tr.prefs.projects/src/au/com/trgtd/tr/prefs/projects/ProjectsOptionsPanel.java
@@ -92,7 +92,7 @@ final class ProjectsOptionsPanel extends JPanel {
         states.add(ProjectsPrefs.ActionState.DOASAP);
         states.add(ProjectsPrefs.ActionState.SCHEDULED);
         states.add(ProjectsPrefs.ActionState.DELEGATED);
-        actionStatesCombo = new TRComboBox(new DefaultComboBoxModel(states.toArray()));
+        actionStatesCombo = new TRComboBox<>(new DefaultComboBoxModel<>(states.toArray(ProjectsPrefs.ActionState[]::new)));
         actionStatesCombo.setMaximumRowCount(states.size());
         printFormatLabel = new JLabel(getMsg("print.format.Label"));
         printFormatCombo = new JComboBox<>(new PageSizeChoice[] { PageSizeChoice.Prompt, PageSizeChoice.A4, PageSizeChoice.Letter });
@@ -164,9 +164,9 @@ final class ProjectsOptionsPanel extends JPanel {
     private JCheckBox createDateCheckBox;
     private JCheckBox startDateCheckBox;
     private JLabel actionStatesLabel;
-    private JComboBox actionStatesCombo;
+    private JComboBox<ProjectsPrefs.ActionState> actionStatesCombo;
     private JLabel printFormatLabel;
-    private JComboBox printFormatCombo;
+    private JComboBox<PageSizeChoice> printFormatCombo;
 
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {

--- a/modules/au.com.trgtd.tr.prefs.ui/src/au/com/trgtd/tr/prefs/ui/GUIOptionsPanel.java
+++ b/modules/au.com.trgtd.tr.prefs.ui/src/au/com/trgtd/tr/prefs/ui/GUIOptionsPanel.java
@@ -176,9 +176,9 @@ final class GUIOptionsPanel extends JPanel {
     private static final String RIGHT = NbBundle.getMessage(clazz, "LBL_Right");
     private static Vector<ComboItem> actions;
     private static Vector<ComboItem> positions;
-    private JComboBox buttonsPositionCombo;
+    private JComboBox<ComboItem> buttonsPositionCombo;
     private JLabel buttonsPositionLabel;
-    private JComboBox initialActionCombo;
+    private JComboBox<ComboItem> initialActionCombo;
     private JLabel initialActionLabel;
 
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents

--- a/modules/au.com.trgtd.tr.swing/src/au/com/trgtd/tr/swing/date/chooser/DateChooserDialog.java
+++ b/modules/au.com.trgtd.tr.swing/src/au/com/trgtd/tr/swing/date/chooser/DateChooserDialog.java
@@ -102,7 +102,7 @@ public class DateChooserDialog extends JDialog implements ItemListener, MouseLis
     /* Headings grid. */
     private JPanel headGrid;
     /* Month selection control. */
-    private JComboBox month;
+    private JComboBox<String> month;
     /* Last month button. */
     private JButton monthLast;
     /* Next month button. */
@@ -112,7 +112,7 @@ public class DateChooserDialog extends JDialog implements ItemListener, MouseLis
     /* Next year button. */
     private JButton yearNext;
     /* Year selection control. */
-    private JComboBox year;
+    private JComboBox<String> year;
     /* "Clear" button. */
     private JButton clear;
     /* "Ok" button. */

--- a/modules/au.com.trgtd.tr.sync.device/src/au/com/trgtd/tr/sync/device/dbx/FileWatcherSupport.java
+++ b/modules/au.com.trgtd.tr.sync.device/src/au/com/trgtd/tr/sync/device/dbx/FileWatcherSupport.java
@@ -127,7 +127,7 @@ public class FileWatcherSupport {
                 while (key != null) {
                     
                     // we have a polled event, now we traverse it and receive all the states from it
-                    for (WatchEvent event : key.pollEvents()) {
+                    for (WatchEvent<?> event : key.pollEvents()) {
 
                         Log.log(LEVEL_DEBUG, "Received {0} event for file: {1}", 
                                 new Object[] {event.kind(), event.context()});

--- a/modules/au.com.trgtd.tr.sync.iphone/src/au/com/trgtd/tr/sync/iphone/SyncDialog.java
+++ b/modules/au.com.trgtd.tr.sync.iphone/src/au/com/trgtd/tr/sync/iphone/SyncDialog.java
@@ -69,7 +69,7 @@ public class SyncDialog extends JDialog {
     private JButton firstNextButton;
     private JButton firstCancelButton;
     private JLabel addrLabel;
-    private JComboBox addrCombo;
+    private JComboBox<NetAddr> addrCombo;
     private JLabel portLabel;
     private JFormattedTextField portField;
     private JPanel infoPanel;
@@ -221,7 +221,7 @@ public class SyncDialog extends JDialog {
 
         List<NetAddr> netAddrs = getNetAddresses();
         addrLabel = new TRLabel(getText("choose.network.address"));
-        addrCombo = new TRComboBox(netAddrs.toArray());
+        addrCombo = new TRComboBox<>(netAddrs.toArray(NetAddr[]::new));
         addrCombo.setFont(new Font("Monospaced", Font.PLAIN, 14));
         addrCombo.addActionListener((ActionEvent e) -> {
             firstNextButton.setEnabled(addrCombo.getSelectedIndex() > -1);

--- a/modules/au.com.trgtd.tr.view.actn/src/au/com/trgtd/tr/view/actn/ActionPanel.java
+++ b/modules/au.com.trgtd.tr.view.actn/src/au/com/trgtd/tr/view/actn/ActionPanel.java
@@ -861,15 +861,15 @@ public final class ActionPanel extends JPanel implements Observer {
         return NbBundle.getMessage(ActionPanel.class, key, p1, p2);
     }
 
-    private ComboBoxModel getTimeComboBoxModel() {
+    private ComboBoxModel<Value> getTimeComboBoxModel() {
         return new TimeComboBoxModel();
     }
 
-    private ComboBoxModel getEnergyComboBoxModel() {
+    private ComboBoxModel<Value> getEnergyComboBoxModel() {
         return new EnergyComboBoxModel();
     }
 
-    private ComboBoxModel getPriorityComboBoxModel() {
+    private ComboBoxModel<Value> getPriorityComboBoxModel() {
         return new PriorityComboBoxModel();
     }
 
@@ -1644,8 +1644,8 @@ if (ass.getDate() == null) {
     private ActionStateASAP stateDoASAP;
     private ActionStateDelegated stateDelegate;
     private ActionStateScheduled stateSchedule;
-    private ComboBoxModel topicsModel;
-    private ComboBoxModel contextsModel;
+    private ComboBoxModel<Topic> topicsModel;
+    private ComboBoxModel<Context> contextsModel;
     private boolean updating;
     private DocumentListener docListenerDescription;
     private FocusAdapter focusAdapterDescription;
@@ -1682,8 +1682,8 @@ if (ass.getDate() == null) {
     private TRLabel successLabel;
     private MTextArea successText;
     private TRLabel contextLabel;
-    private TRComboBox contextCombo;
-    private TRComboBox topicCombo;
+    private TRComboBox<Context> contextCombo;
+    private TRComboBox<Topic> topicCombo;
     private TRLabel topicLabel;
     private DateField createdDateField;
     private TRLabel createdDateLabel;
@@ -1696,13 +1696,13 @@ if (ass.getDate() == null) {
     private TRLabel durationLabel;
     private MinuteSpinner durationMinuteSpinner;
     private TRButton emailButton;
-    private TRComboBox energyCombo;
+    private TRComboBox<Value> energyCombo;
     private TRLabel energyLabel;
     private DateField followupField;
     private TRLabel followupLabel;
     private NotesViewLabel notesViewLabel;
     private NotesViewField notesViewField;
-    private TRComboBox priorityCombo;
+    private TRComboBox<Value> priorityCombo;
     private TRLabel priorityLabel;
     private TRButton recurrenceButton;
     private TRLabel recurrenceLabel;
@@ -1712,9 +1712,9 @@ if (ass.getDate() == null) {
     private MinuteSpinner scheduledMinuteSpinner;
     private DateField startDateField;
     private TRLabel startDateLabel;
-    private TRComboBox statusCombo;
+    private TRComboBox<StatusEnum> statusCombo;
     private TRLabel statusLabel;
-    private TRComboBox timeCombo;
+    private TRComboBox<Value> timeCombo;
     private TRLabel timeLabel;
     private JPanel statusPanel;
     private ActorsComboBox delegateCombo;

--- a/modules/au.com.trgtd.tr.view.actn/src/au/com/trgtd/tr/view/actn/PeriodMonthlyPanel.java
+++ b/modules/au.com.trgtd.tr.view.actn/src/au/com/trgtd/tr/view/actn/PeriodMonthlyPanel.java
@@ -60,11 +60,11 @@ public class PeriodMonthlyPanel extends JPanel {
         return periodMonth.getSelectedDaysText();        
     }
     
-    private ComboBoxModel getDayComboModel() {
+    private ComboBoxModel<OnTheDay> getDayComboModel() {
         return new DefaultComboBoxModel<>(PeriodMonth.OnTheDay.values());
     }
 
-    private ComboBoxModel getNthComboModel() {
+    private ComboBoxModel<OnTheNth> getNthComboModel() {
         return new DefaultComboBoxModel<>(PeriodMonth.OnTheNth.values());
     }
 
@@ -156,10 +156,10 @@ public class PeriodMonthlyPanel extends JPanel {
     private final Dialog parent;
     private final PeriodMonth periodMonth;
     private ButtonGroup buttonGroup;
-    private JComboBox dayCombo;
+    private JComboBox<OnTheDay> dayCombo;
     private JButton daysButton;
     private JRadioButton eachRadio;
-    private JComboBox nthCombo;
+    private JComboBox<OnTheNth> nthCombo;
     private JRadioButton onTheRadio;
     
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents

--- a/modules/au.com.trgtd.tr.view.actn/src/au/com/trgtd/tr/view/actn/PeriodYearlyPanel.java
+++ b/modules/au.com.trgtd.tr.view.actn/src/au/com/trgtd/tr/view/actn/PeriodYearlyPanel.java
@@ -56,11 +56,11 @@ public class PeriodYearlyPanel extends JPanel {
         setEnabled(true);
     }
 
-    private ComboBoxModel getDayComboModel() {
+    private ComboBoxModel<OnTheDay> getDayComboModel() {
         return new DefaultComboBoxModel<>(PeriodMonth.OnTheDay.values());
     }
 
-    private ComboBoxModel getNthComboModel() {
+    private ComboBoxModel<OnTheNth> getNthComboModel() {
         return new DefaultComboBoxModel<>(PeriodMonth.OnTheNth.values());
     }
 
@@ -152,10 +152,10 @@ public class PeriodYearlyPanel extends JPanel {
 
     private final Dialog parent;
     private final PeriodYear periodYear;
-    private JComboBox dayComboBox;
+    private JComboBox<OnTheDay> dayComboBox;
     private JLabel inLabel;
     private JButton monthsButton;
-    private JComboBox nthComboBox;
+    private JComboBox<OnTheNth> nthComboBox;
     private JCheckBox onTheCheckBox;
 
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents

--- a/modules/au.com.trgtd.tr.view.actn/src/au/com/trgtd/tr/view/actn/recurrence/NewRecurrenceWizard.java
+++ b/modules/au.com.trgtd.tr.view.actn/src/au/com/trgtd/tr/view/actn/recurrence/NewRecurrenceWizard.java
@@ -52,7 +52,7 @@ public class NewRecurrenceWizard {
 
         Recurrence recurrence = new Recurrence(data.getNextID(), action);
 
-        WizardDescriptor.Iterator iterator = new NewRecurrenceWizardIterator(recurrence, action);
+        WizardDescriptor.Iterator<WizardDescriptor> iterator = new NewRecurrenceWizardIterator(recurrence, action);
         WizardDescriptor wizardDescriptor = new WizardDescriptor(iterator);
         // {0} will be replaced by WizardDescriptor.Panel.getComponent().getName()
         // {1} will be replaced by WizardDescriptor.Iterator.name()

--- a/modules/au.com.trgtd.tr.view.actn/src/au/com/trgtd/tr/view/actn/recurrence/modify/ModifyRecurrenceWizard.java
+++ b/modules/au.com.trgtd.tr.view.actn/src/au/com/trgtd/tr/view/actn/recurrence/modify/ModifyRecurrenceWizard.java
@@ -67,7 +67,7 @@ public class ModifyRecurrenceWizard {
         if (recurrence == null) {
             return;
         }
-        WizardDescriptor.Iterator iterator = new ModifyRecurrenceWizardIterator(action, recurrence);
+        WizardDescriptor.Iterator<WizardDescriptor> iterator = new ModifyRecurrenceWizardIterator(action, recurrence);
         wizardDescriptor = new WizardDescriptor(iterator);
         wizardDescriptor.setTitleFormat(new MessageFormat("{0}"));
         wizardDescriptor.setTitle(org.openide.util.NbBundle.getMessage(ModifyRecurrenceWizard.class, "modify.recurrence"));

--- a/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/prefs/ActionsPrefsPanel.java
+++ b/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/prefs/ActionsPrefsPanel.java
@@ -104,7 +104,7 @@ final class ActionsPrefsPanel extends JPanel {
 
     private JLabel titleLabel;
     private JLabel fontLabel;
-    private JComboBox fontCombo;
+    private JComboBox<Item> fontCombo;
     private JCheckBox colourCheck;
     private JCheckBox strikeCheck;
     private Vector<Item> items;

--- a/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/ReviewActionsFilters.java
+++ b/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/ReviewActionsFilters.java
@@ -18,7 +18,10 @@
 package au.com.trgtd.tr.view.actns.screens;
 
 import au.com.trgtd.tr.view.ViewUtils;
+import au.com.trgtd.tr.view.actns.screens.filters.ActionsFilter;
+import au.com.trgtd.tr.view.filters.FilterCombo;
 import ca.odell.glazedlists.BasicEventList;
+import ca.odell.glazedlists.EventList;
 import ca.odell.glazedlists.matchers.CompositeMatcherEditor;
 import ca.odell.glazedlists.matchers.MatcherEditor;
 import java.awt.Dimension;
@@ -26,8 +29,7 @@ import java.awt.FlowLayout;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import org.openide.util.Utilities;
-import au.com.trgtd.tr.view.actns.screens.filters.ActionsFilter;
-import au.com.trgtd.tr.view.filters.FilterCombo;
+import tr.model.action.Action;
 
 /**
  * Filters for actions.
@@ -39,7 +41,7 @@ public class ReviewActionsFilters {
     private static final int LABEL_HEIGHT = 12;
     
     private final ActionsScreen screen;
-    private MatcherEditor matcherEditor;
+    private MatcherEditor<Action> matcherEditor;
     private JPanel component;
     
     /** Constructs a new instance. */
@@ -47,10 +49,10 @@ public class ReviewActionsFilters {
         this.screen = screen;
     }
     
-    public MatcherEditor getMatcherEditor() {
+    public MatcherEditor<Action> getMatcherEditor() {
         if (matcherEditor == null) {
-            BasicEventList<MatcherEditor> list = new BasicEventList<>();
-            for (MatcherEditor m : screen.getFilters()) {
+            EventList<MatcherEditor<Action>> list = new BasicEventList<>();
+            for (MatcherEditor<Action> m : screen.getFilters()) {
                 list.add(m);
             }
 //            for (ActionsFilter filter : screen.getFilters()) {
@@ -58,7 +60,7 @@ public class ReviewActionsFilters {
 //                    list.add(filter);
 //                }
 //            }
-            matcherEditor = new CompositeMatcherEditor(list);
+            matcherEditor = new CompositeMatcherEditor<>(list);
         }
         return matcherEditor;
     }

--- a/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/ReviewActionsPanel.java
+++ b/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/ReviewActionsPanel.java
@@ -262,9 +262,9 @@ public class ReviewActionsPanel extends JPanel implements ListSelectionListener,
     }
 
     private FilterDone getDoneFilter() {
-        MatcherEditor matcherEditor = filters.getMatcherEditor();
+        MatcherEditor<Action> matcherEditor = filters.getMatcherEditor();
         if (matcherEditor instanceof CompositeMatcherEditor cme) {
-            for (Object filter : cme.getMatcherEditors().toArray()) {
+            for (Object filter : cme.getMatcherEditors().toArray(Object[]::new)) {
                 if (filter instanceof FilterDone filterDone) {
                     return filterDone;
                 }

--- a/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/ReviewActionsTopComponent.java
+++ b/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/ReviewActionsTopComponent.java
@@ -599,7 +599,7 @@ public final class ReviewActionsTopComponent extends Window implements ActionsPr
 
     public void provide(final List<Action> actions) {
         EventQueue.invokeLater(() -> {
-            Collection collection = new Vector();
+            Collection<Object> collection = new Vector<>();
             collection.add(panel);
             if (actions != null) {
                 for (Action action : actions) {

--- a/modules/au.com.trgtd.tr.view.calendar/src/au/com/trgtd/tr/view/cal/dialog/ActionEditPanel.java
+++ b/modules/au.com.trgtd.tr.view.calendar/src/au/com/trgtd/tr/view/cal/dialog/ActionEditPanel.java
@@ -356,12 +356,12 @@ public final class ActionEditPanel extends JPanel {
     }
 
     private void changedContext(java.awt.event.ActionEvent evt) {
-        TRComboBox combo = (TRComboBox) evt.getSource();
+        TRComboBox<Context> combo = (TRComboBox<Context>) evt.getSource();
         ctlr.setContext((Context) combo.getSelectedItem());
     }
 
     private void changedTopic(java.awt.event.ActionEvent evt) {
-        TRComboBox combo = (TRComboBox) evt.getSource();
+        TRComboBox<Topic> combo = (TRComboBox<Topic>) evt.getSource();
         ctlr.setTopic((Topic) combo.getSelectedItem());
     }
 
@@ -373,15 +373,15 @@ public final class ActionEditPanel extends JPanel {
         return NbBundle.getMessage(ActionEditPanel.class, key, p1, p2);
     }
 
-    private ComboBoxModel getTimeComboBoxModel() {
+    private ComboBoxModel<Value> getTimeComboBoxModel() {
         return new TimeComboBoxModel();
     }
 
-    private ComboBoxModel getEnergyComboBoxModel() {
+    private ComboBoxModel<Value> getEnergyComboBoxModel() {
         return new EnergyComboBoxModel();
     }
 
-    private ComboBoxModel getPriorityComboBoxModel() {
+    private ComboBoxModel<Value> getPriorityComboBoxModel() {
         return new PriorityComboBoxModel();
     }
 
@@ -972,8 +972,8 @@ public final class ActionEditPanel extends JPanel {
     private static final TRLabel fillerLabel2 = new TRLabel("");
     private static final TRLabel fillerLabel3 = new TRLabel("");
     
-    private ComboBoxModel topicsModel;
-    private ComboBoxModel contextsModel;
+    private ComboBoxModel<Topic> topicsModel;
+    private ComboBoxModel<Context> contextsModel;
     private DocumentListener docListenerDescr;
     private DocumentListener docListenerSuccess;
     private ActionListener actionListenerTopic;
@@ -1005,8 +1005,8 @@ public final class ActionEditPanel extends JPanel {
     private TRLabel successLabel;
     private MTextArea successText;
     private TRLabel contextLabel;
-    private TRComboBox contextCombo;
-    private TRComboBox topicCombo;
+    private TRComboBox<Context> contextCombo;
+    private TRComboBox<Topic> topicCombo;
     private TRLabel topicLabel;
     private DateField createdDateField;
     private TRLabel createdDateLabel;
@@ -1019,13 +1019,13 @@ public final class ActionEditPanel extends JPanel {
     private TRLabel durationLabel;
     private MinuteSpinner durationMinuteSpinner;
     private TRButton emailButton;
-    private TRComboBox energyCombo;
+    private TRComboBox<Value> energyCombo;
     private TRLabel energyLabel;
     private DateField followupField;
     private TRLabel followupLabel;
     private NotesViewLabel notesViewLabel;
     private NotesViewField notesViewField;
-    private TRComboBox priorityCombo;
+    private TRComboBox<Value> priorityCombo;
     private TRLabel priorityLabel;
     private DateField scheduledDateField;
     private HourSpinner scheduledHourSpinner;
@@ -1033,9 +1033,9 @@ public final class ActionEditPanel extends JPanel {
     private MinuteSpinner scheduledMinuteSpinner;
     private DateField startDateField;
     private TRLabel startDateLabel;
-    private TRComboBox statusCombo;
+    private TRComboBox<StatusEnum> statusCombo;
     private TRLabel statusLabel;
-    private TRComboBox timeCombo;
+    private TRComboBox<Value> timeCombo;
     private TRLabel timeLabel;
     private JPanel statusPanel;
     private ActorsComboBox delegateCombo;

--- a/modules/au.com.trgtd.tr.view.delegates/src/au/com/trgtd/tr/view/delegates/screen/ActorPanel.java
+++ b/modules/au.com.trgtd.tr.view.delegates/src/au/com/trgtd/tr/view/delegates/screen/ActorPanel.java
@@ -273,7 +273,7 @@ public class ActorPanel extends JPanel implements ListSelectionListener, Observe
         } else if (object instanceof Manager.EventRemove event) {
             Lock lock = actorEventList.getReadWriteLock().writeLock();
             lock.lock();
-            actorEventList.remove(event.item);
+            actorEventList.remove((Actor)event.item);
             lock.unlock();
         } else if (observable instanceof Actor actor) {
             Lock lock = actorEventList.getReadWriteLock().writeLock();

--- a/modules/au.com.trgtd.tr.view.goals/src/au/com/trgtd/tr/view/goals/ChangeLevelAction.java
+++ b/modules/au.com.trgtd.tr.view.goals/src/au/com/trgtd/tr/view/goals/ChangeLevelAction.java
@@ -57,7 +57,7 @@ public class ChangeLevelAction extends CookieAction {
         return HelpCtx.DEFAULT_HELP;
     }
 
-    public Class[] cookieClasses() {
+    public Class<ChangeLevelCookie>[] cookieClasses() {
         return new Class[] {ChangeLevelCookie.class};
     }
 

--- a/modules/au.com.trgtd.tr.view.goals/src/au/com/trgtd/tr/view/goals/GoalNode.java
+++ b/modules/au.com.trgtd.tr.view.goals/src/au/com/trgtd/tr/view/goals/GoalNode.java
@@ -402,7 +402,7 @@ public class GoalNode extends AbstractNode
     }
 
     @Override
-    protected void createPasteTypes(Transferable t, List s) {
+    protected void createPasteTypes(Transferable t, List<PasteType> s) {
         super.createPasteTypes(t, s);
 
         PasteType pasteType = null;

--- a/modules/au.com.trgtd.tr.view.goals/src/au/com/trgtd/tr/view/goals/GoalTopComponent.java
+++ b/modules/au.com.trgtd.tr.view.goals/src/au/com/trgtd/tr/view/goals/GoalTopComponent.java
@@ -127,12 +127,12 @@ public final class GoalTopComponent extends Window implements LookupListener {
             return;
         }
 
-        Collection collection = result.allInstances();
+        Collection<? extends GoalNode> collection = result.allInstances();
         if (collection.isEmpty()) {
 //            panel.initModel(null);
 //            LOG.info("null");
         } else {
-            GoalNode node = (GoalNode)collection.iterator().next();
+            GoalNode node = collection.iterator().next();
             panel.initModel(node.goalCtrl);
             LOG.info("initialising model");
         }

--- a/modules/au.com.trgtd.tr.view.process/src/au/com/trgtd/tr/view/process/ProcessPanel.java
+++ b/modules/au.com.trgtd.tr.view.process/src/au/com/trgtd/tr/view/process/ProcessPanel.java
@@ -1844,7 +1844,7 @@ public final class ProcessPanel extends JPanel implements Observer, ProcessCooki
         return delegationOriginalActionPanel;
     }
     
-    private ComboBoxModel getTimeComboBoxModel() {
+    private ComboBoxModel<Value> getTimeComboBoxModel() {
         if (data != null) {
             Criterion criterion = data.getTimeCriterion();
             if (criterion != null) {
@@ -1854,7 +1854,7 @@ public final class ProcessPanel extends JPanel implements Observer, ProcessCooki
         return new DefaultComboBoxModel<>();
     }
 
-    private ComboBoxModel getEnergyComboBoxModel() {
+    private ComboBoxModel<Value> getEnergyComboBoxModel() {
         if (data != null) {
             Criterion criterion = data.getEnergyCriterion();
             if (criterion != null) {
@@ -1864,7 +1864,7 @@ public final class ProcessPanel extends JPanel implements Observer, ProcessCooki
         return new DefaultComboBoxModel<>();
     }
 
-    private ComboBoxModel getPriorityComboBoxModel() {
+    private ComboBoxModel<Value> getPriorityComboBoxModel() {
         if (data != null) {
             Criterion criterion = data.getPriorityCriterion();
             if (criterion != null) {
@@ -2050,7 +2050,7 @@ public final class ProcessPanel extends JPanel implements Observer, ProcessCooki
     private TRLabel thoughtLabel;
     private TRTextField thoughtText;
     private TRLabel topicLabel;
-    private JComboBox topicCombo;
+    private JComboBox<Topic> topicCombo;
     private ButtonGroup actionableButtonGroup;
     private TRRadioButton actionableYesRadioButton;
     private TRRadioButton actionableNoRadioButton;
@@ -2081,15 +2081,15 @@ public final class ProcessPanel extends JPanel implements Observer, ProcessCooki
     private TRLabel descriptionLabel;
     private TRTextField descrField;
     private TRLabel contextLabel;
-    private JComboBox contextCombo;
+    private JComboBox<Context> contextCombo;
     private TRLabel timeLabel;
-    private JComboBox timeCombo;
+    private JComboBox<Value> timeCombo;
     private TRLabel energyLabel;
-    private JComboBox energyCombo;
+    private JComboBox<Value> energyCombo;
     private TRLabel priorityLabel;
-    private JComboBox priorityCombo;
+    private JComboBox<Value> priorityCombo;
     // Status
-    private JComboBox statusCombo;
+    private JComboBox<StatusEnum> statusCombo;
     private TRLabel statusLabel;
     private TRLabel dueDateLabel;
     private DateField dueDateField;

--- a/modules/au.com.trgtd.tr.view.process/src/au/com/trgtd/tr/view/process/ProcessTopComponent.java
+++ b/modules/au.com.trgtd.tr.view.process/src/au/com/trgtd/tr/view/process/ProcessTopComponent.java
@@ -219,7 +219,7 @@ public final class ProcessTopComponent extends Window implements ProcessNodeProv
             if (panel == null || processNode == null) {
                 getInstanceContent().set(Collections.EMPTY_LIST, null);
             } else {
-                Collection collection = new ArrayList();
+                Collection<ProcessNode> collection = new ArrayList<>();
                 collection.add(processNode);
                 getInstanceContent().set(collection, null);
             }

--- a/modules/au.com.trgtd.tr.view.project/src/au/com/trgtd/tr/view/project/ProjectPanel.java
+++ b/modules/au.com.trgtd.tr.view.project/src/au/com/trgtd/tr/view/project/ProjectPanel.java
@@ -119,7 +119,7 @@ public final class ProjectPanel extends JPanel { // implements Observer {
         descriptionText.requestFocusInWindow();
     }
 
-    private ComboBoxModel getPriorityComboBoxModel() {
+    private ComboBoxModel<Value> getPriorityComboBoxModel() {
         return new PriorityComboBoxModel();
     }
 
@@ -830,9 +830,9 @@ public final class ProjectPanel extends JPanel { // implements Observer {
     private TRLabel descriptionLabel;
     private TRTextField descriptionText;
     private TRLabel topicLabel;
-    private TRComboBox topicCombo;
+    private TRComboBox<Topic> topicCombo;
     private TRLabel priorityLabel;
-    private TRComboBox priorityCombo;
+    private TRComboBox<Value> priorityCombo;
     private TRCheckBox sequencingCheckBox;
     private JLabel seqIncludeLabel;
     private TRCheckBox seqProjectsCheckBox;
@@ -858,7 +858,7 @@ public final class ProjectPanel extends JPanel { // implements Observer {
     private DateField createdDateField;
     private Lookup.Result result;
     private Project project;
-    private ComboBoxModel topicsModel;
+    private ComboBoxModel<Topic> topicsModel;
     private boolean updating;
     private DocumentListener docListenerDescription;
     private DocumentListener docListenerPurpose;

--- a/modules/au.com.trgtd.tr.view.projects/src/au/com/trgtd/tr/view/projects/ProjectNode.java
+++ b/modules/au.com.trgtd.tr.view.projects/src/au/com/trgtd/tr/view/projects/ProjectNode.java
@@ -289,7 +289,7 @@ public class ProjectNode extends AbstractNode implements Observer, EditCookie,
     }
 
     @Override
-    protected void createPasteTypes(Transferable t, List s) {
+    protected void createPasteTypes(Transferable t, List<PasteType> s) {
         super.createPasteTypes(t, s);
         PasteType paste = getDropType(t, DnDConstants.ACTION_COPY, -1);
         if (paste != null) {

--- a/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/filters/MatcherEditorTopic.java
+++ b/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/filters/MatcherEditorTopic.java
@@ -246,7 +246,7 @@ public class MatcherEditorTopic extends MatcherEditorBase
                     } else {
                         all = data.getTopicManager().list();
                     }
-                    MultiChoiceDialog d = new MultiChoiceDialog<>(TopicsComboBox.this, all, tm.getChosen(), true);
+                    MultiChoiceDialog<Topic> d = new MultiChoiceDialog<>(TopicsComboBox.this, all, tm.getChosen(), true);
                     d.setTitle(NbBundle.getMessage(getClass(), "filter-topic"));
                     d.setLocationRelativeTo(TopicsComboBox.this);
                     d.setVisible(true);
@@ -272,7 +272,7 @@ public class MatcherEditorTopic extends MatcherEditorBase
                     } else {
                         all = data.getTopicManager().list();
                     }
-                    MultiChoiceDialog d = new MultiChoiceDialog<>(TopicsComboBox.this, all, tm.getChosen(), true);
+                    MultiChoiceDialog<Topic> d = new MultiChoiceDialog<>(TopicsComboBox.this, all, tm.getChosen(), true);
                     d.setTitle(NbBundle.getMessage(getClass(), "filter-topic"));
                     d.setLocationRelativeTo(TopicsComboBox.this);
                     d.setVisible(true);

--- a/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/linker/RefChooserFilters.java
+++ b/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/linker/RefChooserFilters.java
@@ -18,7 +18,10 @@
 package au.com.trgtd.tr.view.reference.linker;
 
 import au.com.trgtd.tr.view.ViewUtils;
+import au.com.trgtd.tr.view.reference.filters.MatcherEditorSearchText;
+import au.com.trgtd.tr.view.reference.filters.MatcherEditorTopic;
 import ca.odell.glazedlists.BasicEventList;
+import ca.odell.glazedlists.EventList;
 import ca.odell.glazedlists.matchers.CompositeMatcherEditor;
 import ca.odell.glazedlists.matchers.MatcherEditor;
 import java.awt.Component;
@@ -28,8 +31,7 @@ import java.util.Vector;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import au.com.trgtd.tr.view.reference.filters.MatcherEditorSearchText;
-import au.com.trgtd.tr.view.reference.filters.MatcherEditorTopic;
+import tr.model.information.Information;
 
 /**
  * Filters for information references.
@@ -44,12 +46,12 @@ class RefChooserFilters {
         matcherEditorSearch = new MatcherEditorSearchText();
     }
     
-    public MatcherEditor getMatcherEditor() {
+    public MatcherEditor<Information> getMatcherEditor() {
         if (matcherEditor == null) {
-            BasicEventList<MatcherEditor> list = new BasicEventList<>();
+            EventList<MatcherEditor<Information>> list = new BasicEventList<>();
             list.add(matcherEditorTopics);
             list.add(matcherEditorSearch);
-            matcherEditor = new CompositeMatcherEditor(list);
+            matcherEditor = new CompositeMatcherEditor<>(list);
         }
         return matcherEditor;
     }
@@ -89,7 +91,7 @@ class RefChooserFilters {
 
     public final MatcherEditorTopic matcherEditorTopics;
     public final MatcherEditorSearchText matcherEditorSearch;
-    private MatcherEditor matcherEditor;
+    private MatcherEditor<Information> matcherEditor;
     private JComponent component;
     
 }

--- a/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/linker/RefChooserPanel.java
+++ b/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/linker/RefChooserPanel.java
@@ -67,7 +67,7 @@ class RefChooserPanel extends JPanel implements Observer {
 
     private Data data;
     private RefChooserFilters refsFilters;
-    private MatcherEditor refsMatcherEditor;
+    private MatcherEditor<Information> refsMatcherEditor;
     private JXTable refsTable;
     private RefChooserTableFormat refsTableFormat;
     private EventTableModel<Information> refsTableModel;
@@ -138,7 +138,7 @@ class RefChooserPanel extends JPanel implements Observer {
         refsList = (data == null ? new Vector<>() : data.getInformationManager().list());
         refsEventList = new BasicEventList<>();
         refsEventList.addAll(refsList);
-        FilterList refsFilterList = new FilterList(refsEventList, refsMatcherEditor);
+        FilterList<Information> refsFilterList = new FilterList<>(refsEventList, refsMatcherEditor);
         refsSortedList = new SortedList<>(refsFilterList);
         refsTableFormat = new RefChooserTableFormat();
         refsTableModel = new EventTableModel<>(refsSortedList, refsTableFormat);

--- a/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/screen/ReferencePanel.java
+++ b/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/screen/ReferencePanel.java
@@ -200,7 +200,7 @@ public class ReferencePanel extends JPanel {
     private NotesViewField notesField;
     private JScrollPane notesScroll;
     private TRLabel topicLabel;
-    private JComboBox topicCombo;
+    private JComboBox<Topic> topicCombo;
     private TopicsComboBoxModel topicsModel;
     private FocusListener descrFocusListener;
     private ActionListener topicActionListener;

--- a/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/screen/ReferencesFilters.java
+++ b/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/screen/ReferencesFilters.java
@@ -32,6 +32,7 @@ import au.com.trgtd.tr.view.reference.filters.MatcherEditorCreatedFrom;
 import au.com.trgtd.tr.view.reference.filters.MatcherEditorCreatedTo;
 import au.com.trgtd.tr.view.reference.filters.MatcherEditorSearch;
 import au.com.trgtd.tr.view.reference.filters.MatcherEditorTopic;
+import tr.model.information.Information;
 
 /**
  * Filters for information references.
@@ -48,14 +49,14 @@ public class ReferencesFilters {
         matcherEditorSearch = new MatcherEditorSearch();
     }
     
-    public MatcherEditor getMatcherEditor() {
+    public MatcherEditor<Information> getMatcherEditor() {
         if (matcherEditor == null) {
-            BasicEventList<MatcherEditor> list = new BasicEventList<>();
+            BasicEventList<MatcherEditor<Information>> list = new BasicEventList<>();
             list.add(matcherEditorCreatedFrom);
             list.add(matcherEditorCreatedTo);
             list.add(matcherEditorTopics);
             list.add(matcherEditorSearch);
-            matcherEditor = new CompositeMatcherEditor(list);
+            matcherEditor = new CompositeMatcherEditor<>(list);
         }
         return matcherEditor;
     }
@@ -107,7 +108,7 @@ public class ReferencesFilters {
     private final MatcherEditorCreatedTo matcherEditorCreatedTo;
     private final MatcherEditorTopic matcherEditorTopics;
     private final MatcherEditorSearch matcherEditorSearch;
-    private MatcherEditor matcherEditor;
+    private MatcherEditor<Information> matcherEditor;
     private JComponent component;
     
 }

--- a/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/screen/ReferencesPanel.java
+++ b/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/screen/ReferencesPanel.java
@@ -66,7 +66,7 @@ public class ReferencesPanel extends JPanel implements ListSelectionListener, Ob
     /**
      * Creates a new instance for the given reference provider and filters.
      */
-    public ReferencesPanel(ReferenceNodeProvider refsProvider, MatcherEditor matcherEditor) {
+    public ReferencesPanel(ReferenceNodeProvider refsProvider, MatcherEditor<Information> matcherEditor) {
         super();
         this.refsProvider = refsProvider;
         this.refsMatcherEditor = matcherEditor;
@@ -87,7 +87,7 @@ public class ReferencesPanel extends JPanel implements ListSelectionListener, Ob
         refsEventList = new BasicEventList<>();
         refsEventList.addAll(refsList);
         
-        FilterList refsFilterList = new FilterList(refsEventList, refsMatcherEditor);
+        FilterList<Information> refsFilterList = new FilterList<>(refsEventList, refsMatcherEditor);
         
         data.getInformationManager().addObserver(this);
         
@@ -308,7 +308,7 @@ public class ReferencesPanel extends JPanel implements ListSelectionListener, Ob
     private final static Logger LOG = Logger.getLogger("tr.view.reference");
     
     private final ReferenceNodeProvider refsProvider;
-    private final MatcherEditor refsMatcherEditor;
+    private final MatcherEditor<Information> refsMatcherEditor;
     private final Data data;
     
     private JXTable refsTable;

--- a/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/screen/ReferencesTopComponent.java
+++ b/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/screen/ReferencesTopComponent.java
@@ -189,7 +189,7 @@ public final class ReferencesTopComponent extends Window implements ReferenceNod
         return filters;
     }
     
-    private MatcherEditor getMatcherEditor() {
+    private MatcherEditor<Information> getMatcherEditor() {
         return getFilters().getMatcherEditor();
     }
     

--- a/modules/au.com.trgtd.tr.view.someday/src/au/com/trgtd/tr/view/someday/screen/SomedayFilters.java
+++ b/modules/au.com.trgtd.tr.view.someday/src/au/com/trgtd/tr/view/someday/screen/SomedayFilters.java
@@ -32,6 +32,7 @@ import au.com.trgtd.tr.view.someday.filters.MatcherEditorCreatedFrom;
 import au.com.trgtd.tr.view.someday.filters.MatcherEditorCreatedTo;
 import au.com.trgtd.tr.view.someday.filters.MatcherEditorSearch;
 import au.com.trgtd.tr.view.someday.filters.MatcherEditorTopic;
+import tr.model.future.Future;
 
 /**
  * Filters for future items.
@@ -48,14 +49,14 @@ public class SomedayFilters {
         matcherEditorSearch = new MatcherEditorSearch();
     }
     
-    public MatcherEditor getMatcherEditor() {
+    public MatcherEditor<Future> getMatcherEditor() {
         if (matcherEditor == null) {
-            BasicEventList<MatcherEditor> list = new BasicEventList<>();
+            BasicEventList<MatcherEditor<Future>> list = new BasicEventList<>();
             list.add(matcherEditorCreatedFrom);
             list.add(matcherEditorCreatedTo);
             list.add(matcherEditorTopics);
             list.add(matcherEditorSearch);
-            matcherEditor = new CompositeMatcherEditor(list);
+            matcherEditor = new CompositeMatcherEditor<>(list);
         }
         return matcherEditor;
     }
@@ -107,7 +108,7 @@ public class SomedayFilters {
     private final MatcherEditorCreatedTo matcherEditorCreatedTo;
     private final MatcherEditorTopic matcherEditorTopics;
     private final MatcherEditorSearch matcherEditorSearch;
-    private MatcherEditor matcherEditor;
+    private MatcherEditor<Future> matcherEditor;
     private JComponent component;
     
 }

--- a/modules/au.com.trgtd.tr.view.someday/src/au/com/trgtd/tr/view/someday/screen/SomedayPanel.java
+++ b/modules/au.com.trgtd.tr.view.someday/src/au/com/trgtd/tr/view/someday/screen/SomedayPanel.java
@@ -231,7 +231,7 @@ public class SomedayPanel extends JPanel {
     private TRLabel tickleLabel;
     private DateField tickleField;
     private TRLabel topicLabel;
-    private JComboBox topicCombo;
+    private JComboBox<Topic> topicCombo;
     private TopicsComboBoxModel topicsModel;
     private FocusListener descrFocusListener;
     private ActionListener topicActionListener;

--- a/modules/au.com.trgtd.tr.view.someday/src/au/com/trgtd/tr/view/someday/screen/SomedaysPanel.java
+++ b/modules/au.com.trgtd.tr.view.someday/src/au/com/trgtd/tr/view/someday/screen/SomedaysPanel.java
@@ -66,7 +66,7 @@ public class SomedaysPanel extends JPanel implements ListSelectionListener, Obse
     /**
      * Creates a new instance for the given future item provider and filters.
      */
-    public SomedaysPanel(SomedayNodeProvider futuresProvider, MatcherEditor matcherEditor) {
+    public SomedaysPanel(SomedayNodeProvider futuresProvider, MatcherEditor<Future> matcherEditor) {
         super();
         this.refsProvider = futuresProvider;
         this.refsMatcherEditor = matcherEditor;
@@ -87,7 +87,7 @@ public class SomedaysPanel extends JPanel implements ListSelectionListener, Obse
         refsEventList = new BasicEventList<>();
         refsEventList.addAll(refsList);
         
-        FilterList refsFilterList = new FilterList<>(refsEventList, refsMatcherEditor);
+        FilterList<Future> refsFilterList = new FilterList<>(refsEventList, refsMatcherEditor);
         
         data.getFutureManager().addObserver(this);
         
@@ -310,7 +310,7 @@ public class SomedaysPanel extends JPanel implements ListSelectionListener, Obse
     private final static Logger LOG = Logger.getLogger("tr.view.future");
     
     private final SomedayNodeProvider refsProvider;
-    private final MatcherEditor refsMatcherEditor;
+    private final MatcherEditor<Future> refsMatcherEditor;
     private final Data data;
     
     private JXTable futuresTable;

--- a/modules/au.com.trgtd.tr.view/src/au/com/trgtd/tr/view/CriteriaChangePanel.java
+++ b/modules/au.com.trgtd.tr.view/src/au/com/trgtd/tr/view/CriteriaChangePanel.java
@@ -88,13 +88,13 @@ public class CriteriaChangePanel extends JPanel {
         return NbBundle.getMessage(getClass(), key);
     }
 
-    private DefaultComboBoxModel priorities;
-    private DefaultComboBoxModel times;
-    private DefaultComboBoxModel energies;
+    private DefaultComboBoxModel<Value> priorities;
+    private DefaultComboBoxModel<Value> times;
+    private DefaultComboBoxModel<Value> energies;
     private JLabel criteriaLabel;
     private JLabel valueLabel;
-    private JComboBox criteriaCombo;
-    private JComboBox valueCombo;
+    private JComboBox<Criteria> criteriaCombo;
+    private JComboBox<Value> valueCombo;
 
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {

--- a/modules/tr.model/src/tr/model/project/Project.java
+++ b/modules/tr.model/src/tr/model/project/Project.java
@@ -1028,7 +1028,7 @@ public class Project extends ObservableImpl
             return;
         }
         synchronized (this) {
-            Vector reorderedChildren = new Vector<>(children);
+            Vector<Item> reorderedChildren = new Vector<>(children);
             for (int i = 0; i < srcItems.length; i++) {
                 if (contains(srcItems[i]) && contains(dstItems[i])) {
                     int dstIndex = children.indexOf(dstItems[i]);


### PR DESCRIPTION
This is the third of a series of 4 PRs, each resolving part of the warnings in NetBeans.

This third one applies generics for variable declarations where possible.

Also:
- organizes a few imports
- switches  from `collection.toArray()` to `collection.toArray(new T[0])`