### PR TITLE
refactor: Introduce more generics

### DIFF
--- a/modules/au.com.trgtd.tr.swing/src/au/com/trgtd/tr/swing/date/combo/DateCombo.java
+++ b/modules/au.com.trgtd.tr.swing/src/au/com/trgtd/tr/swing/date/combo/DateCombo.java
@@ -36,7 +36,7 @@ import au.com.trgtd.tr.swing.date.chooser.DateChooser;
  *
  * @author Jeremy Moore
  */
-public class DateCombo extends TRComboBox implements ActionListener {
+public class DateCombo extends TRComboBox<DateItem> implements ActionListener {
     
     /** Property for the date selection. */
     public static final String PROPERTY_DATE = "date";

--- a/modules/au.com.trgtd.tr.view.actn/src/au/com/trgtd/tr/view/actn/StatusComboBoxModel.java
+++ b/modules/au.com.trgtd.tr.view.actn/src/au/com/trgtd/tr/view/actn/StatusComboBoxModel.java
@@ -25,7 +25,7 @@ import javax.swing.DefaultComboBoxModel;
 /**
  * ComboBoxModel for action states.
  */
-public class StatusComboBoxModel extends DefaultComboBoxModel {
+public class StatusComboBoxModel extends DefaultComboBoxModel<StatusEnum> {
     
     private List<StatusEnum> states;
     
@@ -44,7 +44,7 @@ public class StatusComboBoxModel extends DefaultComboBoxModel {
     /**
      * Implement ListModel.getElementAt(int index).
      */
-    public Object getElementAt(int index) {
+    public StatusEnum getElementAt(int index) {
         return states.get(index);
     }
     

--- a/modules/au.com.trgtd.tr.view.actn/src/au/com/trgtd/tr/view/actn/recurrence/PeriodTypeComboBox.java
+++ b/modules/au.com.trgtd.tr.view.actn/src/au/com/trgtd/tr/view/actn/recurrence/PeriodTypeComboBox.java
@@ -27,7 +27,7 @@ import tr.model.action.PeriodType;
  *
  * @author <a href="mailto:jimoore@netspace.net.au">Jeremy Moore</a>
  */
-public class PeriodTypeComboBox extends TRComboBox {
+public class PeriodTypeComboBox extends TRComboBox<PeriodType> {
 
     /**
      * Constructs a new default instance.

--- a/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/ReviewActionsTableFormat.java
+++ b/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/ReviewActionsTableFormat.java
@@ -44,7 +44,7 @@ import tr.model.topic.Topic;
  *
  * @author Jeremy Moore
  */
-public class ReviewActionsTableFormat implements AdvancedTableFormat, WritableTableFormat {
+public class ReviewActionsTableFormat implements AdvancedTableFormat<Action>, WritableTableFormat<Action> {
     
     private final ActionsScreen screen;
     
@@ -65,16 +65,10 @@ public class ReviewActionsTableFormat implements AdvancedTableFormat, WritableTa
         }
     }
     
-    public Object getColumnValue(Object object, int column) {
-        
-        Action action;
-        if (object instanceof Action a) {
-            action = a;
-        } else {
-//            throw new IllegalStateException("Row data missing.");
+    public Object getColumnValue(Action action, int column) {
+        if (action == null)
             return null;
-        }
-        
+
         Project project = (Project)action.getParent();
         
         ActionsColumn field;
@@ -419,13 +413,13 @@ public class ReviewActionsTableFormat implements AdvancedTableFormat, WritableTa
         styledValue.setBackground(topic.getBackground());
         return styledValue;
     };
-    
-    public boolean isEditable(Object baseObject, int column) {
+
+    public boolean isEditable(Action baseObject, int column) {
 //        return screen.getColumns().get(column).getColumnIndex() == ActionsColumn.INDEX_DONE;
         return false;
     }
-    
-    public Object setColumnValue(Object baseObject, Object editedValue, int column) {
+
+    public Action setColumnValue(Action baseObject, Object editedValue, int column) {
 //        
 //        assert(screen.getColumns().get(column).getColumnIndex() == ActionsColumn.INDEX_DONE);
 //        assert(baseObject instanceof Action);

--- a/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/ReviewActionsTopComponent.java
+++ b/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/ReviewActionsTopComponent.java
@@ -88,8 +88,6 @@ import au.com.trgtd.tr.view.contexts.ContextChangeAction;
 import au.com.trgtd.tr.view.projects.PostponeActionAction;
 import au.com.trgtd.tr.view.projects.SetDoneAction;
 import au.com.trgtd.tr.view.topics.TopicChangeAction;
-import java.util.logging.Level;
-//import org.openide.actions.DeleteAction;
 
 /**
  * Top component for the review actions windows.

--- a/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/filters/FilterContext.java
+++ b/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/filters/FilterContext.java
@@ -121,7 +121,7 @@ public class FilterContext extends FilterChoice implements PropertyChangeListene
         }
     }
     
-    private class ContextsComboBoxModel extends DefaultComboBoxModel implements Observer {
+    private class ContextsComboBoxModel extends DefaultComboBoxModel<Context> implements Observer {
         private final ContextAll contextAll;
         private final ContextMultiple contextMultiple;
         private final ContextMultipleEdit contextMultipleEdit;
@@ -171,7 +171,7 @@ public class FilterContext extends FilterChoice implements PropertyChangeListene
         
         /** Implement ListModel.getElementAt(int index). */
         @Override
-        public Object getElementAt(int index) {
+        public Context getElementAt(int index) {
             return contexts.get(index);
         }
         
@@ -188,7 +188,7 @@ public class FilterContext extends FilterChoice implements PropertyChangeListene
         }
     }
     
-    public class ContextsCombo extends FilterComboAbstract {
+    public class ContextsCombo extends FilterComboAbstract<Context> {
         
         private final ActionListener listener;
         
@@ -214,7 +214,7 @@ public class FilterContext extends FilterChoice implements PropertyChangeListene
         }
         
         @Override
-        public JComboBox getJComboBox() {
+        public JComboBox<Context> getJComboBox() {
             return this;
         }
         
@@ -229,7 +229,7 @@ public class FilterContext extends FilterChoice implements PropertyChangeListene
                     } else {
                         all = data.getContextManager().list();
                     }
-                    MultiChoiceDialog d = new MultiChoiceDialog<>(ContextsCombo.this, all, m.getChosen(), true);
+                    MultiChoiceDialog<Context> d = new MultiChoiceDialog<>(ContextsCombo.this, all, m.getChosen(), true);
                     d.setTitle(NbBundle.getMessage(getClass(), "filter-context"));
                     d.setLocationRelativeTo(ContextsCombo.this);
                     d.setVisible(true);
@@ -256,7 +256,7 @@ public class FilterContext extends FilterChoice implements PropertyChangeListene
                     } else {
                         all = data.getContextManager().list();
                     }
-                    MultiChoiceDialog d = new MultiChoiceDialog<>(ContextsCombo.this, all, m.getChosen(), true);
+                    MultiChoiceDialog<Context> d = new MultiChoiceDialog<>(ContextsCombo.this, all, m.getChosen(), true);
                     d.setTitle(NbBundle.getMessage(getClass(), "filter-context"));
                     d.setLocationRelativeTo(ContextsCombo.this);
                     d.setVisible(true);

--- a/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/filters/FilterCriterionEnergy.java
+++ b/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/filters/FilterCriterionEnergy.java
@@ -131,7 +131,7 @@ public class FilterCriterionEnergy extends FilterCriterion implements PropertyCh
         }
     }
     
-    private class EnergyComboBoxModel extends DefaultComboBoxModel implements Observer {
+    private class EnergyComboBoxModel extends DefaultComboBoxModel<Value> implements Observer {
         private final ValueAll all;
         private final ValueMultiple multiple;
         private final ValueMultipleEdit multipleEdit;
@@ -180,7 +180,7 @@ public class FilterCriterionEnergy extends FilterCriterion implements PropertyCh
         }
         
         /** Implement ListModel.getElementAt(int index). */
-        public Object getElementAt(int index) {
+        public Value getElementAt(int index) {
             return values.get(index);
         }
         
@@ -196,7 +196,7 @@ public class FilterCriterionEnergy extends FilterCriterion implements PropertyCh
         }
     }
     
-    public class EnergyCombo extends FilterComboAbstract {
+    public class EnergyCombo extends FilterComboAbstract<Value> {
         
         private final ActionListener listener;
         
@@ -232,7 +232,7 @@ public class FilterCriterionEnergy extends FilterCriterion implements PropertyCh
                     } else {
                         all = data.getEnergyCriterion().values.list();
                     }
-                    MultiChoiceDialog d = new MultiChoiceDialog<>(EnergyCombo.this, all, m.getChosen(), false);
+                    MultiChoiceDialog<Value> d = new MultiChoiceDialog<>(EnergyCombo.this, all, m.getChosen(), false);
                     d.setTitle(NbBundle.getMessage(getClass(), "filter-energy"));
                     d.setLocationRelativeTo(EnergyCombo.this);
                     d.setVisible(true);
@@ -259,7 +259,7 @@ public class FilterCriterionEnergy extends FilterCriterion implements PropertyCh
                     } else {
                         all = data.getEnergyCriterion().values.list();
                     }
-                    MultiChoiceDialog d = new MultiChoiceDialog<>(EnergyCombo.this, all, m.getChosen(), false);
+                    MultiChoiceDialog<Value> d = new MultiChoiceDialog<>(EnergyCombo.this, all, m.getChosen(), false);
                     d.setTitle(NbBundle.getMessage(getClass(), "filter-energy"));
                     d.setLocationRelativeTo(EnergyCombo.this);
                     d.setVisible(true);

--- a/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/filters/FilterCriterionPriority.java
+++ b/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/filters/FilterCriterionPriority.java
@@ -129,7 +129,7 @@ public class FilterCriterionPriority extends FilterCriterion
         }
     }
     
-    private class PriorityComboBoxModel extends DefaultComboBoxModel implements Observer {
+    private class PriorityComboBoxModel extends DefaultComboBoxModel<Value> implements Observer {
         private final ValueAll all;
         private final ValueMultiple multiple;
         private final ValueMultipleEdit multipleEdit;
@@ -178,7 +178,7 @@ public class FilterCriterionPriority extends FilterCriterion
         }
         
         /** Implement ListModel.getElementAt(int index). */
-        public Object getElementAt(int index) {
+        public Value getElementAt(int index) {
             return values.get(index);
         }
         
@@ -194,7 +194,7 @@ public class FilterCriterionPriority extends FilterCriterion
         }
     }
     
-    public class PriorityCombo extends FilterComboAbstract {
+    public class PriorityCombo extends FilterComboAbstract<Value> {
         
         private final ActionListener listener;
         
@@ -230,7 +230,7 @@ public class FilterCriterionPriority extends FilterCriterion
                     } else {
                         all = data.getPriorityCriterion().values.list();
                     }
-                    MultiChoiceDialog d = new MultiChoiceDialog<>(PriorityCombo.this, all, m.getChosen(), false);
+                    MultiChoiceDialog<Value> d = new MultiChoiceDialog<>(PriorityCombo.this, all, m.getChosen(), false);
                     d.setTitle(NbBundle.getMessage(getClass(), "filter-priority"));
                     d.setLocationRelativeTo(PriorityCombo.this);
                     d.setVisible(true);
@@ -257,7 +257,7 @@ public class FilterCriterionPriority extends FilterCriterion
                     } else {
                         all = data.getPriorityCriterion().values.list();
                     }
-                    MultiChoiceDialog d = new MultiChoiceDialog<>(PriorityCombo.this, all, m.getChosen(), false);
+                    MultiChoiceDialog<Value> d = new MultiChoiceDialog<>(PriorityCombo.this, all, m.getChosen(), false);
                     d.setTitle(NbBundle.getMessage(getClass(), "filter-priority"));
                     d.setLocationRelativeTo(PriorityCombo.this);
                     d.setVisible(true);

--- a/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/filters/FilterCriterionTime.java
+++ b/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/filters/FilterCriterionTime.java
@@ -131,7 +131,7 @@ public class FilterCriterionTime extends FilterCriterion implements PropertyChan
         }
     }
     
-    private class TimeComboBoxModel extends DefaultComboBoxModel implements Observer {
+    private class TimeComboBoxModel extends DefaultComboBoxModel<Value> implements Observer {
         private final ValueAll all;
         private final ValueMultiple multiple;
         private final ValueMultipleEdit multipleEdit;
@@ -180,7 +180,7 @@ public class FilterCriterionTime extends FilterCriterion implements PropertyChan
         }
         
         /** Implement ListModel.getElementAt(int index). */
-        public Object getElementAt(int index) {
+        public Value getElementAt(int index) {
             return values.get(index);
         }
         
@@ -196,7 +196,7 @@ public class FilterCriterionTime extends FilterCriterion implements PropertyChan
         }
     }
     
-    public class TimeCombo extends FilterComboAbstract {
+    public class TimeCombo extends FilterComboAbstract<Value> {
         
         private final ActionListener listener;
         
@@ -232,7 +232,7 @@ public class FilterCriterionTime extends FilterCriterion implements PropertyChan
                     } else {
                         all = data.getTimeCriterion().values.list();
                     }
-                    MultiChoiceDialog d = new MultiChoiceDialog<>(TimeCombo.this, all, m.getChosen(), false);
+                    MultiChoiceDialog<Value> d = new MultiChoiceDialog<>(TimeCombo.this, all, m.getChosen(), false);
                     d.setTitle(NbBundle.getMessage(getClass(), "filter-time"));
                     d.setLocationRelativeTo(TimeCombo.this);
                     d.setVisible(true);
@@ -259,7 +259,7 @@ public class FilterCriterionTime extends FilterCriterion implements PropertyChan
                     } else {
                         all = data.getTimeCriterion().values.list();
                     }
-                    MultiChoiceDialog d = new MultiChoiceDialog<>(TimeCombo.this, all, m.getChosen(), false);
+                    MultiChoiceDialog<Value> d = new MultiChoiceDialog<>(TimeCombo.this, all, m.getChosen(), false);
                     d.setTitle(NbBundle.getMessage(getClass(), "filter-time"));
                     d.setLocationRelativeTo(TimeCombo.this);
                     d.setVisible(true);

--- a/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/filters/FilterDone.java
+++ b/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/filters/FilterDone.java
@@ -151,13 +151,13 @@ public class FilterDone extends FilterChoice implements PropertyChangeListener {
         }
     }
     
-    private class DoneChoiceComboBoxModel extends DefaultComboBoxModel {
+    private class DoneChoiceComboBoxModel extends DefaultComboBoxModel<Choice> {
         private final Choice[] items = new Choice[] {
             new All(),
             new Done(),
             new ToDo()
         };
-        public Object getElementAt(int index) {
+        public Choice getElementAt(int index) {
             return items[index];
         }
         public int getSize() {
@@ -165,7 +165,7 @@ public class FilterDone extends FilterChoice implements PropertyChangeListener {
         }
     }
     
-    private class DoneChoiceComboBox extends FilterComboAbstract {
+    private class DoneChoiceComboBox extends FilterComboAbstract<Choice> {
         
         public DoneChoiceComboBox(DoneChoiceComboBoxModel model) {
             super(model);

--- a/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/filters/FilterSearch.java
+++ b/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/filters/FilterSearch.java
@@ -187,7 +187,7 @@ public final class FilterSearch extends FilterChoice implements PropertyChangeLi
         }
     }
 
-    private class SearchComboBoxModel extends DefaultComboBoxModel {
+    private class SearchComboBoxModel extends DefaultComboBoxModel<String> {
 
         public final Vector<String> searches = new Vector<>();
 
@@ -203,7 +203,7 @@ public final class FilterSearch extends FilterChoice implements PropertyChangeLi
         }
 
         @Override
-        public Object getElementAt(int index) {
+        public String getElementAt(int index) {
             return searches.get(index);
         }
 
@@ -213,7 +213,7 @@ public final class FilterSearch extends FilterChoice implements PropertyChangeLi
         }
     }
 
-    private final class SearchComboBox extends FilterComboAbstract {
+    private final class SearchComboBox extends FilterComboAbstract<String> {
 
         public SearchComboBox() {
             super(new SearchComboBoxModel());

--- a/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/filters/FilterStatus.java
+++ b/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/filters/FilterStatus.java
@@ -232,7 +232,7 @@ public class FilterStatus extends FilterChoice implements PropertyChangeListener
         }
     }
     
-    private class StatusComboBoxModel extends DefaultComboBoxModel {
+    private class StatusComboBoxModel extends DefaultComboBoxModel<Choice> {
         
         private final Choice all = new All();
         private final Multiple multiple = new Multiple();
@@ -268,7 +268,7 @@ public class FilterStatus extends FilterChoice implements PropertyChangeListener
             }
         }
         
-        public Object getElementAt(int index) {
+        public Choice getElementAt(int index) {
             return items[index];
         }
         
@@ -277,7 +277,7 @@ public class FilterStatus extends FilterChoice implements PropertyChangeListener
         }
     }
     
-    public class StatusComboBox extends FilterComboAbstract {
+    public class StatusComboBox extends FilterComboAbstract<Choice> {
         
         private final Vector<Choice> options = new Vector<>();
         private final ActionListener listener;
@@ -311,7 +311,7 @@ public class FilterStatus extends FilterChoice implements PropertyChangeListener
             public void actionPerformed(ActionEvent e) {
                 Object object = getSelectedItem();
                 if (object instanceof Multiple m) {
-                    MultiChoiceDialog d = new MultiChoiceDialog<>(StatusComboBox.this, options, m.getChosen(), true);
+                    MultiChoiceDialog<Choice> d = new MultiChoiceDialog<>(StatusComboBox.this, options, m.getChosen(), true);
                     d.setTitle(NbBundle.getMessage(getClass(), "filter-status"));
                     d.setLocationRelativeTo(StatusComboBox.this);
                     d.setVisible(true);
@@ -329,7 +329,7 @@ public class FilterStatus extends FilterChoice implements PropertyChangeListener
                 if (object instanceof ChoiceMultipleEdit) {
                     StatusComboBoxModel model = (StatusComboBoxModel)getModel();
                     Multiple m = model.multiple;
-                    MultiChoiceDialog d = new MultiChoiceDialog<>(StatusComboBox.this, options, m.getChosen(), true);
+                    MultiChoiceDialog<Choice> d = new MultiChoiceDialog<>(StatusComboBox.this, options, m.getChosen(), true);
                     d.setTitle(NbBundle.getMessage(getClass(), "filter-topic"));
                     d.setLocationRelativeTo(StatusComboBox.this);
                     d.setVisible(true);

--- a/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/filters/FilterTopic.java
+++ b/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/filters/FilterTopic.java
@@ -194,7 +194,7 @@ public class FilterTopic extends FilterChoice implements PropertyChangeListener 
         }
     }
     
-    private class TopicsComboBoxModel extends DefaultComboBoxModel implements Observer {
+    private class TopicsComboBoxModel extends DefaultComboBoxModel<Topic> implements Observer {
         private final TopicAll all;
         private final TopicMultiple multiple;
         private final TopicMultipleEdit multipleEdit;
@@ -243,7 +243,7 @@ public class FilterTopic extends FilterChoice implements PropertyChangeListener 
         }
         
         /** Implement ListModel.getElementAt(int index). */
-        public Object getElementAt(int index) {
+        public Topic getElementAt(int index) {
             return topics.get(index);
         }
         
@@ -259,7 +259,7 @@ public class FilterTopic extends FilterChoice implements PropertyChangeListener 
         }
     }
     
-    public class TopicsComboBox extends FilterComboAbstract {
+    public class TopicsComboBox extends FilterComboAbstract<Topic> {
         
         private final ActionListener listener;
         
@@ -294,7 +294,7 @@ public class FilterTopic extends FilterChoice implements PropertyChangeListener 
                     } else {
                         all = data.getTopicManager().list();
                     }
-                    MultiChoiceDialog d = new MultiChoiceDialog<>(TopicsComboBox.this, all, tm.getChosen(), true);
+                    MultiChoiceDialog<Topic> d = new MultiChoiceDialog<>(TopicsComboBox.this, all, tm.getChosen(), true);
                     d.setTitle(NbBundle.getMessage(getClass(), "filter-topic"));
                     d.setLocationRelativeTo(TopicsComboBox.this);
                     d.setVisible(true);
@@ -321,7 +321,7 @@ public class FilterTopic extends FilterChoice implements PropertyChangeListener 
                     } else {
                         all = data.getTopicManager().list();
                     }
-                    MultiChoiceDialog d = new MultiChoiceDialog<>(TopicsComboBox.this, all, tm.getChosen(), true);
+                    MultiChoiceDialog<Topic> d = new MultiChoiceDialog<>(TopicsComboBox.this, all, tm.getChosen(), true);
                     d.setTitle(NbBundle.getMessage(getClass(), "filter-topic"));
                     d.setLocationRelativeTo(TopicsComboBox.this);
                     d.setVisible(true);

--- a/modules/au.com.trgtd.tr.view.calendar/src/au/com/trgtd/tr/view/cal/CalModelImp.java
+++ b/modules/au.com.trgtd.tr.view.calendar/src/au/com/trgtd/tr/view/cal/CalModelImp.java
@@ -42,7 +42,7 @@ import tr.model.action.ActionStateScheduled;
  */
 public class CalModelImp implements CalModel {
 
-    private static final Comparator COMPARATOR = (Comparator<CalEvent>) (CalEvent e1, CalEvent e2) -> {
+    private static final Comparator<CalEvent> COMPARATOR = (Comparator<CalEvent>) (CalEvent e1, CalEvent e2) -> {
         Action a1 = e1.getAction();
         Action a2 = e2.getAction();
         int c = a1.getTopic().compareTo(a2.getTopic());

--- a/modules/au.com.trgtd.tr.view.contexts/src/au/com/trgtd/tr/view/contexts/ContextsComboBox.java
+++ b/modules/au.com.trgtd.tr.view.contexts/src/au/com/trgtd/tr/view/contexts/ContextsComboBox.java
@@ -18,17 +18,18 @@
 package au.com.trgtd.tr.view.contexts;
 
 import au.com.trgtd.tr.appl.Constants;
+import au.com.trgtd.tr.swing.TRComboBox;
 import java.awt.Font;
 import javax.swing.ComboBoxModel;
 import org.openide.util.NbBundle;
-import au.com.trgtd.tr.swing.TRComboBox;
+import tr.model.context.Context;
 
 /**
  * Combo box for contexts.
  *
  * @author Jeremy Moore
  */
-public class ContextsComboBox extends TRComboBox {
+public class ContextsComboBox extends TRComboBox<Context> {
 
     /**
      * Constructs a new instance with the default model.
@@ -41,7 +42,7 @@ public class ContextsComboBox extends TRComboBox {
      * Constructs a new instance for the given data model.
      * @param model The contexts combo box model.
      */
-    public ContextsComboBox(ComboBoxModel model) {
+    public ContextsComboBox(ComboBoxModel<Context> model) {
         super(model);
         setFont(getFont().deriveFont(Font.PLAIN));
         setMaximumRowCount(Constants.COMBO_MAX_ROWS);

--- a/modules/au.com.trgtd.tr.view.contexts/src/au/com/trgtd/tr/view/contexts/ContextsComboBoxModel.java
+++ b/modules/au.com.trgtd.tr.view.contexts/src/au/com/trgtd/tr/view/contexts/ContextsComboBoxModel.java
@@ -36,7 +36,7 @@ import au.com.trgtd.tr.util.Observer;
  *
  * @author Jeremy Moore
  */
-public class ContextsComboBoxModel extends DefaultComboBoxModel implements Observer {
+public class ContextsComboBoxModel extends DefaultComboBoxModel<Context> implements Observer {
 
     private Manager<Context> contextManager;
     private List<Context> contexts;
@@ -95,7 +95,7 @@ public class ContextsComboBoxModel extends DefaultComboBoxModel implements Obser
      * Implement ListModel.getElementAt(int index).
      */
     @Override
-    public Object getElementAt(int index) {
+    public Context getElementAt(int index) {
         return contexts.get(index);
     }
 

--- a/modules/au.com.trgtd.tr.view.criteria/src/au/com/trgtd/tr/view/criteria/CriterionComboBoxModel.java
+++ b/modules/au.com.trgtd.tr.view.criteria/src/au/com/trgtd/tr/view/criteria/CriterionComboBoxModel.java
@@ -21,11 +21,12 @@ import javax.swing.DefaultComboBoxModel;
 import tr.model.criteria.Criterion; 
 import au.com.trgtd.tr.util.Observable;
 import au.com.trgtd.tr.util.Observer;
+import tr.model.criteria.Value;
 
 /**
  * Criterion ComboBoxModel.
  */
-public class CriterionComboBoxModel extends DefaultComboBoxModel implements Observer {
+public class CriterionComboBoxModel extends DefaultComboBoxModel<Value> implements Observer {
     
     private final Criterion criterion;
     
@@ -43,7 +44,7 @@ public class CriterionComboBoxModel extends DefaultComboBoxModel implements Obse
      * Implement ListModel.getElementAt(int index).
      */
     @Override
-    public Object getElementAt(int index) {
+    public Value getElementAt(int index) {
         return criterion.values.get(index);
     }
     

--- a/modules/au.com.trgtd.tr.view.criteria/src/au/com/trgtd/tr/view/criteria/EnergyComboBox.java
+++ b/modules/au.com.trgtd.tr.view.criteria/src/au/com/trgtd/tr/view/criteria/EnergyComboBox.java
@@ -21,13 +21,14 @@ import au.com.trgtd.tr.appl.Constants;
 import au.com.trgtd.tr.swing.TRComboBox;
 import java.awt.Font;
 import javax.swing.ComboBoxModel;
+import tr.model.criteria.Value;
 
 /**
  * Combo box for energy criteria.
  *
  * @author Jeremy Moore
  */
-public class EnergyComboBox extends TRComboBox {
+public class EnergyComboBox extends TRComboBox<Value> {
 
     /**
      * Constructs a new default instance.
@@ -40,7 +41,7 @@ public class EnergyComboBox extends TRComboBox {
      * Constructs a new instance for the given data model.
      * @param model The combo box model.
      */
-    public EnergyComboBox(ComboBoxModel model) {
+    public EnergyComboBox(ComboBoxModel<Value> model) {
         super(model);
         setFont(getFont().deriveFont(Font.PLAIN));
         setMaximumRowCount(Constants.COMBO_MAX_ROWS);

--- a/modules/au.com.trgtd.tr.view.criteria/src/au/com/trgtd/tr/view/criteria/EnergyComboBoxModel.java
+++ b/modules/au.com.trgtd.tr.view.criteria/src/au/com/trgtd/tr/view/criteria/EnergyComboBoxModel.java
@@ -25,11 +25,12 @@ import tr.model.DataLookup;
 import tr.model.criteria.Criterion;
 import au.com.trgtd.tr.util.Observable;
 import au.com.trgtd.tr.util.Observer;
+import tr.model.criteria.Value;
 
 /**
  * Combo box model for energy critera.
  */
-public class EnergyComboBoxModel extends DefaultComboBoxModel implements Observer {
+public class EnergyComboBoxModel extends DefaultComboBoxModel<Value> implements Observer {
 
     private Criterion criterion;
     private Lookup.Result result;
@@ -69,7 +70,7 @@ public class EnergyComboBoxModel extends DefaultComboBoxModel implements Observe
      * Implement ListModel.getElementAt(int index).
      */
     @Override
-    public Object getElementAt(int index) {
+    public Value getElementAt(int index) {
         return criterion == null || !criterion.isUse() ? null : criterion.values.get(index);
     }
 

--- a/modules/au.com.trgtd.tr.view.criteria/src/au/com/trgtd/tr/view/criteria/PriorityComboBox.java
+++ b/modules/au.com.trgtd.tr.view.criteria/src/au/com/trgtd/tr/view/criteria/PriorityComboBox.java
@@ -21,13 +21,14 @@ import au.com.trgtd.tr.appl.Constants;
 import au.com.trgtd.tr.swing.TRComboBox;
 import java.awt.Font;
 import javax.swing.ComboBoxModel;
+import tr.model.criteria.Value;
 
 /**
  * Combo box for priority criteria.
  *
  * @author Jeremy Moore
  */
-public class PriorityComboBox extends TRComboBox {
+public class PriorityComboBox extends TRComboBox<Value> {
 
     /**
      * Constructs a new default instance.
@@ -40,7 +41,7 @@ public class PriorityComboBox extends TRComboBox {
      * Constructs a new instance for the given data model.
      * @param model The combo box model.
      */
-    public PriorityComboBox(ComboBoxModel model) {
+    public PriorityComboBox(ComboBoxModel<Value> model) {
         super(model);
         setFont(getFont().deriveFont(Font.PLAIN));
         setMaximumRowCount(Constants.COMBO_MAX_ROWS);

--- a/modules/au.com.trgtd.tr.view.criteria/src/au/com/trgtd/tr/view/criteria/PriorityComboBoxModel.java
+++ b/modules/au.com.trgtd.tr.view.criteria/src/au/com/trgtd/tr/view/criteria/PriorityComboBoxModel.java
@@ -25,11 +25,12 @@ import tr.model.DataLookup;
 import tr.model.criteria.Criterion;
 import au.com.trgtd.tr.util.Observable;
 import au.com.trgtd.tr.util.Observer;
+import tr.model.criteria.Value;
 
 /**
  * Combo box model for priority critera.
  */
-public class PriorityComboBoxModel extends DefaultComboBoxModel implements Observer {
+public class PriorityComboBoxModel extends DefaultComboBoxModel<Value> implements Observer {
 
     private Criterion criterion;
     private Lookup.Result result;
@@ -69,7 +70,7 @@ public class PriorityComboBoxModel extends DefaultComboBoxModel implements Obser
      * Implement ListModel.getElementAt(int index).
      */
     @Override
-    public Object getElementAt(int index) {
+    public Value getElementAt(int index) {
         return criterion == null || !criterion.isUse() ? null : criterion.values.get(index);
     }
 

--- a/modules/au.com.trgtd.tr.view.criteria/src/au/com/trgtd/tr/view/criteria/TimeComboBox.java
+++ b/modules/au.com.trgtd.tr.view.criteria/src/au/com/trgtd/tr/view/criteria/TimeComboBox.java
@@ -21,13 +21,14 @@ import au.com.trgtd.tr.appl.Constants;
 import au.com.trgtd.tr.swing.TRComboBox;
 import java.awt.Font;
 import javax.swing.ComboBoxModel;
+import tr.model.criteria.Value;
 
 /**
  * Combo box for time criteria.
  *
  * @author Jeremy Moore
  */
-public class TimeComboBox extends TRComboBox {
+public class TimeComboBox extends TRComboBox<Value> {
 
     /**
      * Constructs a new default instance.
@@ -40,7 +41,7 @@ public class TimeComboBox extends TRComboBox {
      * Constructs a new instance for the given data model.
      * @param model The combo box model.
      */
-    public TimeComboBox(ComboBoxModel model) {
+    public TimeComboBox(ComboBoxModel<Value> model) {
         super(model);
         setFont(getFont().deriveFont(Font.PLAIN));
         setMaximumRowCount(Constants.COMBO_MAX_ROWS);

--- a/modules/au.com.trgtd.tr.view.criteria/src/au/com/trgtd/tr/view/criteria/TimeComboBoxModel.java
+++ b/modules/au.com.trgtd.tr.view.criteria/src/au/com/trgtd/tr/view/criteria/TimeComboBoxModel.java
@@ -25,11 +25,12 @@ import org.openide.util.LookupEvent;
 import tr.model.Data;
 import tr.model.DataLookup;
 import tr.model.criteria.Criterion;
+import tr.model.criteria.Value;
 
 /**
  * Combo box model for time criteria.
  */
-public class TimeComboBoxModel extends DefaultComboBoxModel implements Observer {
+public class TimeComboBoxModel extends DefaultComboBoxModel<Value> implements Observer {
 
     private Criterion criterion;
     private Lookup.Result result;
@@ -66,7 +67,7 @@ public class TimeComboBoxModel extends DefaultComboBoxModel implements Observer 
     }
 
     @Override
-    public Object getElementAt(int index) {
+    public Value getElementAt(int index) {
         return criterion == null || !criterion.isUse() ? null : criterion.values.get(index);
     }
 

--- a/modules/au.com.trgtd.tr.view.delegates/src/au/com/trgtd/tr/view/delegates/screen/ActorsTableFormat.java
+++ b/modules/au.com.trgtd.tr.view.delegates/src/au/com/trgtd/tr/view/delegates/screen/ActorsTableFormat.java
@@ -121,11 +121,9 @@ public class ActorsTableFormat implements AdvancedTableFormat<Actor> {
         throw new IllegalStateException();
     }
     
-    public static class StringComparator implements Comparator {
+    public static class StringComparator implements Comparator<String> {
         @Override
-        public int compare(Object o1, Object o2) {
-            String s1 = (String)o1;
-            String s2 = (String)o2;
+        public int compare(String s1, String s2) {
             return s1.compareToIgnoreCase(s2);
         }
     }

--- a/modules/au.com.trgtd.tr.view.filters/src/au/com/trgtd/tr/view/filters/FilterCombo.java
+++ b/modules/au.com.trgtd.tr.view.filters/src/au/com/trgtd/tr/view/filters/FilterCombo.java
@@ -25,7 +25,7 @@ import javax.swing.JComboBox;
  *
  * @author Jeremy Moore
  */
-public interface FilterCombo {
+public interface FilterCombo<E> {
     
     /** Property for value selection changes. */
     public static final String PROPERTY_VALUE = "value";
@@ -42,7 +42,7 @@ public interface FilterCombo {
     
     public void startChangeEvents();
     
-    public JComboBox getJComboBox();
+    public JComboBox<E> getJComboBox();
     
     public void addValueChangeListener(PropertyChangeListener listener);
     
@@ -54,7 +54,7 @@ public interface FilterCombo {
     
     public void setSelectedIndex(int anIndex);
     
-    public Object getItemAt(int index);
+    public E getItemAt(int index);
     
     public int getItemCount();
     

--- a/modules/au.com.trgtd.tr.view.filters/src/au/com/trgtd/tr/view/filters/FilterComboAbstract.java
+++ b/modules/au.com.trgtd.tr.view.filters/src/au/com/trgtd/tr/view/filters/FilterComboAbstract.java
@@ -28,9 +28,9 @@ import javax.swing.JComboBox;
  *
  * @author Jeremy Moore
  */
-public abstract class FilterComboAbstract extends TRComboBox implements FilterCombo {
+public abstract class FilterComboAbstract<E> extends TRComboBox<E> implements FilterCombo<E> {
     
-    public FilterComboAbstract(ComboBoxModel model) {
+    public FilterComboAbstract(ComboBoxModel<E> model) {
         super(model);
         setPreferredSize(new Dimension(FilterCombo.WIDTH, FilterCombo.HEIGHT));
 //      putClientProperty("JComponent.sizeVariant", "small");
@@ -39,7 +39,7 @@ public abstract class FilterComboAbstract extends TRComboBox implements FilterCo
         
     }
     
-    public JComboBox getJComboBox() {
+    public JComboBox<E> getJComboBox() {
         return this;
     }
     

--- a/modules/au.com.trgtd.tr.view.filters/src/au/com/trgtd/tr/view/filters/FilterComboDate.java
+++ b/modules/au.com.trgtd.tr.view.filters/src/au/com/trgtd/tr/view/filters/FilterComboDate.java
@@ -53,7 +53,7 @@ public class FilterComboDate extends DateCombo implements FilterCombo {
         firePropertyChange(FilterCombo.PROPERTY_VALUE, null, null);
     }
     
-    public JComboBox getJComboBox() {
+    public JComboBox<DateItem> getJComboBox() {
         return this;
     }
     

--- a/modules/au.com.trgtd.tr.view.goals/src/au/com/trgtd/tr/view/goals/GoalsTopComponent.java
+++ b/modules/au.com.trgtd.tr.view.goals/src/au/com/trgtd/tr/view/goals/GoalsTopComponent.java
@@ -43,6 +43,7 @@ import org.openide.explorer.ExplorerUtils;
 import org.openide.explorer.view.OutlineView;
 import org.openide.nodes.Node;
 import org.openide.nodes.Node.Property;
+import org.openide.nodes.PropertySupport;
 import org.openide.util.HelpCtx;
 import org.openide.util.ImageUtilities;
 import org.openide.util.Lookup;
@@ -88,7 +89,7 @@ public final class GoalsTopComponent extends Window
         manager.setRootContext(rootNode);
 
         GoalCtrl goal = manager.getExploredContext().getLookup().lookup(GoalCtrl.class);
-        Property[] props = new Property[]{
+        Property<PropertySupport.ReadOnly<?>>[] props = new Property[]{
             new PropertyAchieved(goal),
             new PropertyLevel(goal),
             new PropertyTopic(goal),};

--- a/modules/au.com.trgtd.tr.view.goals/src/au/com/trgtd/tr/view/goals/levels/LevelsTopComponent.java
+++ b/modules/au.com.trgtd.tr.view.goals/src/au/com/trgtd/tr/view/goals/levels/LevelsTopComponent.java
@@ -42,6 +42,7 @@ import org.openide.explorer.ExplorerManager;
 import org.openide.explorer.ExplorerUtils;
 import org.openide.explorer.view.OutlineView;
 import org.openide.nodes.Node.Property;
+import org.openide.nodes.PropertySupport;
 import org.openide.util.HelpCtx;
 import org.openide.util.ImageUtilities;
 import org.openide.util.Lookup;
@@ -85,7 +86,7 @@ public final class LevelsTopComponent extends Window implements ExplorerManager.
 
         LevelCtrl level = explorerManager.getExploredContext().getLookup().lookup(LevelCtrl.class);
 
-        Property[] props = new Property[] {
+        Property<PropertySupport.ReadOnly<?>>[] props = new Property[] {
             new PropertyGoalsIcon(level),
             new PropertyCanHaveProjects(level),
             new PropertyCanHaveStartDate(level),

--- a/modules/au.com.trgtd.tr.view.goals/src/au/com/trgtd/tr/view/goals/levels/combo/GoalIconsComboBox.java
+++ b/modules/au.com.trgtd.tr.view.goals/src/au/com/trgtd/tr/view/goals/levels/combo/GoalIconsComboBox.java
@@ -33,7 +33,7 @@ import tr.model.goals.ctrl.GoalIcons;
  *
  * @author Jeremy Moore
  */
-public class GoalIconsComboBox extends JComboBox {
+public class GoalIconsComboBox extends JComboBox<GoalIcon> {
 
     /**
      * Constructs a new default instance.
@@ -46,7 +46,7 @@ public class GoalIconsComboBox extends JComboBox {
 //      setToolTipText(NbBundle.getMessage(getClass(), "TTT_LevelsComboBox"));
     }
 
-    private static class GoalIconsComboBoxModel extends DefaultComboBoxModel {
+    private static class GoalIconsComboBoxModel extends DefaultComboBoxModel<GoalIcon>{
 
         private final GoalIcon[] goalIcons;
         
@@ -59,7 +59,7 @@ public class GoalIconsComboBox extends JComboBox {
         }
 
         @Override
-        public Object getElementAt(int index) {
+        public GoalIcon getElementAt(int index) {
             return goalIcons[index];
         }
 
@@ -69,11 +69,11 @@ public class GoalIconsComboBox extends JComboBox {
         }
     }
 
-    public static class GoalIconsRenderer extends JLabel implements ListCellRenderer {
+    public static class GoalIconsRenderer extends JLabel implements  ListCellRenderer<GoalIcon> {
 
-        private final ListCellRenderer std;
+        private final ListCellRenderer<? super GoalIcon> std;
 
-        public GoalIconsRenderer(ListCellRenderer std) {
+        public GoalIconsRenderer(ListCellRenderer<? super GoalIcon> std) {
             if (std == null) {
                 throw new NullPointerException("Standard renderer is null.");
             }
@@ -81,11 +81,12 @@ public class GoalIconsComboBox extends JComboBox {
         }
 
         @Override
-        public Component getListCellRendererComponent(JList list, Object value,
+        public Component getListCellRendererComponent(JList<? extends GoalIcon> list, GoalIcon goalIcon,
                 int index, boolean isSelected, boolean cellHasFocus) {
 
-            JLabel lbl = (JLabel)std.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-            if (value instanceof GoalIcon goalIcon) {
+            JLabel lbl = (JLabel)std.getListCellRendererComponent(list, goalIcon, index, isSelected, cellHasFocus);
+
+            if (goalIcon != null) {
                 lbl.setIcon(goalIcon.icon);
                 lbl.setText("");
             }

--- a/modules/au.com.trgtd.tr.view.goals/src/au/com/trgtd/tr/view/goals/levels/combo/LevelsComboBox.java
+++ b/modules/au.com.trgtd.tr.view.goals/src/au/com/trgtd/tr/view/goals/levels/combo/LevelsComboBox.java
@@ -22,13 +22,14 @@ import au.com.trgtd.tr.swing.TRComboBox;
 import java.awt.Font;
 import javax.swing.ComboBoxModel;
 import org.openide.util.NbBundle;
+import tr.model.goals.ctrl.LevelCtrl;
 
 /**
  * Combo box for topics.
  *
  * @author Jeremy Moore
  */
-public class LevelsComboBox extends TRComboBox {
+public class LevelsComboBox extends TRComboBox<LevelCtrl> {
 
     /**
      * Constructs a new default instance.
@@ -41,7 +42,7 @@ public class LevelsComboBox extends TRComboBox {
      * Constructs a new instance for the given data model.
      * @param model The topics combo box model.
      */
-    public LevelsComboBox(ComboBoxModel model) {
+    public LevelsComboBox(ComboBoxModel<LevelCtrl> model) {
         super(model);
         setFont(getFont().deriveFont(Font.PLAIN));
         setMaximumRowCount(Constants.COMBO_MAX_ROWS);

--- a/modules/au.com.trgtd.tr.view.goals/src/au/com/trgtd/tr/view/goals/levels/combo/LevelsComboBoxModel.java
+++ b/modules/au.com.trgtd.tr.view.goals/src/au/com/trgtd/tr/view/goals/levels/combo/LevelsComboBoxModel.java
@@ -30,7 +30,7 @@ import tr.model.goals.ctrl.LevelsCtrlLookup;
  *
  * @author Jeremy Moore
  */
-public class LevelsComboBoxModel extends DefaultComboBoxModel implements PropertyChangeListener {
+public class LevelsComboBoxModel extends DefaultComboBoxModel<LevelCtrl> implements PropertyChangeListener {
     
     private final LevelsCtrl levelsCtrl;
     private List<LevelCtrl> levels;
@@ -46,7 +46,7 @@ public class LevelsComboBoxModel extends DefaultComboBoxModel implements Propert
     }
     
     @Override
-    public Object getElementAt(int index) {
+    public LevelCtrl getElementAt(int index) {
         synchronized(this) {
             return levels.get(index);
         }

--- a/modules/au.com.trgtd.tr.view.project/src/au/com/trgtd/tr/view/project/SequencingModel.java
+++ b/modules/au.com.trgtd.tr.view.project/src/au/com/trgtd/tr/view/project/SequencingModel.java
@@ -19,14 +19,13 @@ package au.com.trgtd.tr.view.project;
 
 import java.util.List;
 import java.util.Vector;
-
 import javax.swing.DefaultComboBoxModel;
 import tr.model.project.Sequencing;
 
 /**
  * Sequencing ComboBoxModel.
  */ 
-public class SequencingModel extends DefaultComboBoxModel {
+public class SequencingModel extends DefaultComboBoxModel<Sequencing> {
     
     private List<Sequencing> types;
     
@@ -42,7 +41,7 @@ public class SequencingModel extends DefaultComboBoxModel {
      * Implement ListModel.getElementAt(int index).
      */
     @Override
-    public Object getElementAt(int index) {
+    public Sequencing getElementAt(int index) {
         return types.get(index);
     }
     

--- a/modules/au.com.trgtd.tr.view.project/src/au/com/trgtd/tr/view/project/combo/ProjectsComboBox.java
+++ b/modules/au.com.trgtd.tr.view.project/src/au/com/trgtd/tr/view/project/combo/ProjectsComboBox.java
@@ -29,7 +29,7 @@ import au.com.trgtd.tr.view.project.combo.ProjectsComboBoxModel.ProjectItem;
  *
  * @author Jeremy Moore
  */
-public class ProjectsComboBox extends TRComboBox {
+public class ProjectsComboBox extends TRComboBox<ProjectItem> {
 
     /** Constructs a new instance. */
     public ProjectsComboBox() {
@@ -65,21 +65,19 @@ public class ProjectsComboBox extends TRComboBox {
     }
 
     @Override
-    public Object getSelectedItem() {
+    public Project getSelectedItem() {
         Object item = super.getSelectedItem();
         if (item instanceof ProjectItem projectItem) {
             return projectItem.project;
+        } else if (item instanceof Project project) {
+            return project;
         }
-        return item;
+        return null;
     }
 
     @Override
-    public Object getItemAt(int index) {
-        Object item = super.getItemAt(index);
-        if (item instanceof ProjectItem projectItem) {
-            return projectItem.project;
-        }
-        return item;        
-    }    
-    
+    public ProjectItem getItemAt(int index) {
+        return super.getItemAt(index);
+    }
+
 }

--- a/modules/au.com.trgtd.tr.view.project/src/au/com/trgtd/tr/view/project/combo/ProjectsComboBoxModel.java
+++ b/modules/au.com.trgtd.tr.view.project/src/au/com/trgtd/tr/view/project/combo/ProjectsComboBoxModel.java
@@ -29,11 +29,12 @@ import tr.model.DataLookup;
 import tr.model.project.Project;
 import au.com.trgtd.tr.util.Observable;
 import au.com.trgtd.tr.util.Observer;
+import au.com.trgtd.tr.view.project.combo.ProjectsComboBoxModel.ProjectItem;
 
 /**
  * Projects combo box model.
  */
-class ProjectsComboBoxModel extends DefaultComboBoxModel implements Observer {
+class ProjectsComboBoxModel extends DefaultComboBoxModel<ProjectItem> implements Observer {
     
     private List<ProjectItem> projectItems;
 
@@ -51,7 +52,7 @@ class ProjectsComboBoxModel extends DefaultComboBoxModel implements Observer {
      * Implement ListModel.getElementAt(int index).
      */
     @Override
-    public Object getElementAt(int index) {
+    public ProjectItem getElementAt(int index) {
         try {
             return projectItems.get(index);            
         } catch (IndexOutOfBoundsException ex) {

--- a/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/filters/MatcherEditorSearch.java
+++ b/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/filters/MatcherEditorSearch.java
@@ -100,7 +100,7 @@ public class MatcherEditorSearch extends MatcherEditorBase implements PropertyCh
         }
     }
     
-    private class SearchComboBoxModel extends DefaultComboBoxModel {
+    private class SearchComboBoxModel extends DefaultComboBoxModel<String> {
         
         public final Vector<String> searches = new Vector<>();
         
@@ -115,7 +115,7 @@ public class MatcherEditorSearch extends MatcherEditorBase implements PropertyCh
             }
         }
         
-        public Object getElementAt(int index) {
+        public String getElementAt(int index) {
             return searches.get(index);
         }
         
@@ -130,7 +130,7 @@ public class MatcherEditorSearch extends MatcherEditorBase implements PropertyCh
         searchCombo.fireValueChange();
     }
 
-    private class SearchComboBox extends FilterComboAbstract {
+    private class SearchComboBox extends FilterComboAbstract<String> {
         
         public SearchComboBox() {
             super(new SearchComboBoxModel());

--- a/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/filters/MatcherEditorTopic.java
+++ b/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/filters/MatcherEditorTopic.java
@@ -140,7 +140,7 @@ public class MatcherEditorTopic extends MatcherEditorBase
         }
     }
     
-    private class TopicsComboBoxModel extends DefaultComboBoxModel implements Observer {
+    private class TopicsComboBoxModel extends DefaultComboBoxModel<Topic> implements Observer {
         private final TopicAll all;
         private final TopicMultiple multiple;
         private final TopicMultipleEdit multipleEdit;
@@ -188,7 +188,7 @@ public class MatcherEditorTopic extends MatcherEditorBase
         }
         
         /** Implement ListModel.getElementAt(int index). */
-        public Object getElementAt(int index) {
+        public Topic getElementAt(int index) {
             return topics.get(index);
         }
         
@@ -210,7 +210,7 @@ public class MatcherEditorTopic extends MatcherEditorBase
         comboBox.fireValueChange();
     }
     
-    public class TopicsComboBox extends FilterComboAbstract {
+    public class TopicsComboBox extends FilterComboAbstract<Topic> {
         
         private final ActionListener listener;
         

--- a/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/linker/RefChooserTableFormat.java
+++ b/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/linker/RefChooserTableFormat.java
@@ -33,7 +33,7 @@ import tr.model.topic.Topic;
  *
  * @author Jeremy Moore
  */
-class RefChooserTableFormat implements AdvancedTableFormat {
+class RefChooserTableFormat implements AdvancedTableFormat<Information> {
     
     private static Class clazz = RefChooserTableFormat.class;
     
@@ -49,8 +49,7 @@ class RefChooserTableFormat implements AdvancedTableFormat {
         throw new IllegalStateException();
     }
     
-    public Object getColumnValue(Object baseObject, int column) {       
-        Information info = (Information)baseObject;        
+    public Object getColumnValue(Information info, int column) {
         switch (column) {
             case 0: {
                 Color bg = info.getTopic().getBackground();

--- a/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/screen/ReferencesTableFormat.java
+++ b/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/screen/ReferencesTableFormat.java
@@ -39,7 +39,7 @@ import au.com.trgtd.tr.util.DateUtils;
  *
  * @author Jeremy Moore
  */
-public class ReferencesTableFormat implements AdvancedTableFormat {
+public class ReferencesTableFormat implements AdvancedTableFormat<Information> {
     
     private static Class clazz = ReferencesTableFormat.class;
     
@@ -57,7 +57,7 @@ public class ReferencesTableFormat implements AdvancedTableFormat {
         throw new IllegalStateException();
     }
     
-    public Object getColumnValue(Object baseObject, int column) {
+    public Object getColumnValue(Information baseObject, int column) {
         
         Information info = (Information)baseObject;
         

--- a/modules/au.com.trgtd.tr.view.someday/src/au/com/trgtd/tr/view/someday/filters/MatcherEditorSearch.java
+++ b/modules/au.com.trgtd.tr.view.someday/src/au/com/trgtd/tr/view/someday/filters/MatcherEditorSearch.java
@@ -101,7 +101,7 @@ public class MatcherEditorSearch extends MatcherEditorBase
         }
     }
     
-    private class SearchComboBoxModel extends DefaultComboBoxModel {
+    private class SearchComboBoxModel extends DefaultComboBoxModel<String> {
         
         public final Vector<String> searches = new Vector<>();
         
@@ -117,7 +117,7 @@ public class MatcherEditorSearch extends MatcherEditorBase
         }
         
         @Override
-        public Object getElementAt(int index) {
+        public String getElementAt(int index) {
             return searches.get(index);
         }
         
@@ -133,7 +133,7 @@ public class MatcherEditorSearch extends MatcherEditorBase
         searchCombo.fireValueChange();
     }
     
-    private class SearchComboBox extends FilterComboAbstract {
+    private class SearchComboBox extends FilterComboAbstract<String> {
         
         public SearchComboBox() {
             super(new SearchComboBoxModel());

--- a/modules/au.com.trgtd.tr.view.someday/src/au/com/trgtd/tr/view/someday/filters/MatcherEditorTopic.java
+++ b/modules/au.com.trgtd.tr.view.someday/src/au/com/trgtd/tr/view/someday/filters/MatcherEditorTopic.java
@@ -139,7 +139,7 @@ public class MatcherEditorTopic extends MatcherEditorBase implements PropertyCha
         }
     }
     
-    private class TopicsComboBoxModel extends DefaultComboBoxModel implements Observer {
+    private class TopicsComboBoxModel extends DefaultComboBoxModel<Topic> implements Observer {
         private final TopicAll all;
         private final TopicMultiple multiple;
         private final TopicMultipleEdit multipleEdit;
@@ -189,7 +189,7 @@ public class MatcherEditorTopic extends MatcherEditorBase implements PropertyCha
         }
         
         /** Implement ListModel.getElementAt(int index). */
-        public Object getElementAt(int index) {
+        public Topic getElementAt(int index) {
             return topics.get(index);
         }
         
@@ -211,7 +211,7 @@ public class MatcherEditorTopic extends MatcherEditorBase implements PropertyCha
         comboBox.fireValueChange();
     }
     
-    public class TopicsComboBox extends FilterComboAbstract {
+    public class TopicsComboBox extends FilterComboAbstract<Topic> {
         
         private final ActionListener listener;
         
@@ -247,7 +247,7 @@ public class MatcherEditorTopic extends MatcherEditorBase implements PropertyCha
                     } else {
                         all = data.getTopicManager().list();
                     }
-                    MultiChoiceDialog d = new MultiChoiceDialog<>(TopicsComboBox.this, all, tm.getChosen(), true);
+                    MultiChoiceDialog<Topic> d = new MultiChoiceDialog<>(TopicsComboBox.this, all, tm.getChosen(), true);
                     d.setTitle(NbBundle.getMessage(getClass(), "filter-topic"));
                     d.setLocationRelativeTo(TopicsComboBox.this);
                     d.setVisible(true);
@@ -273,7 +273,7 @@ public class MatcherEditorTopic extends MatcherEditorBase implements PropertyCha
                     } else {
                         all = data.getTopicManager().list();
                     }
-                    MultiChoiceDialog d = new MultiChoiceDialog<>(TopicsComboBox.this, all, tm.getChosen(), true);
+                    MultiChoiceDialog<Topic> d = new MultiChoiceDialog<>(TopicsComboBox.this, all, tm.getChosen(), true);
                     d.setTitle(NbBundle.getMessage(getClass(), "filter-topic"));
                     d.setLocationRelativeTo(TopicsComboBox.this);
                     d.setVisible(true);

--- a/modules/au.com.trgtd.tr.view.someday/src/au/com/trgtd/tr/view/someday/screen/SomedaysTableFormat.java
+++ b/modules/au.com.trgtd.tr.view.someday/src/au/com/trgtd/tr/view/someday/screen/SomedaysTableFormat.java
@@ -39,7 +39,7 @@ import au.com.trgtd.tr.util.DateUtils;
  *
  * @author Jeremy Moore
  */
-public class SomedaysTableFormat implements AdvancedTableFormat {
+public class SomedaysTableFormat implements AdvancedTableFormat<Future> {
     
     private static Class clazz = SomedaysTableFormat.class;
     
@@ -58,10 +58,7 @@ public class SomedaysTableFormat implements AdvancedTableFormat {
         throw new IllegalStateException();
     }
     
-    public Object getColumnValue(Object baseObject, int column) {
-        
-        Future future = (Future)baseObject;
-        
+    public Object getColumnValue(Future future, int column) {
         Color bg = future.getTopic().getBackground();
         Color fg = future.getTopic().getForeground();
         

--- a/modules/au.com.trgtd.tr.view.topics/src/au/com/trgtd/tr/view/topics/TopicsComboBox.java
+++ b/modules/au.com.trgtd.tr.view.topics/src/au/com/trgtd/tr/view/topics/TopicsComboBox.java
@@ -22,13 +22,14 @@ import java.awt.Font;
 import javax.swing.ComboBoxModel;
 import org.openide.util.NbBundle;
 import au.com.trgtd.tr.swing.TRComboBox;
+import tr.model.topic.Topic;
 
 /**
  * Combo box for topics.
  *
  * @author Jeremy Moore
  */
-public class TopicsComboBox extends TRComboBox {
+public class TopicsComboBox extends TRComboBox<Topic> {
 
     /**
      * Constructs a new default instance.
@@ -41,7 +42,7 @@ public class TopicsComboBox extends TRComboBox {
      * Constructs a new instance for the given data model.
      * @param model The topics combo box model.
      */
-    public TopicsComboBox(ComboBoxModel model) {
+    public TopicsComboBox(ComboBoxModel<Topic> model) {
         super(model);
         setRenderer(new TopicsListCellRenderer(this.getRenderer()));
         setFont(getFont().deriveFont(Font.PLAIN));

--- a/modules/au.com.trgtd.tr.view.topics/src/au/com/trgtd/tr/view/topics/TopicsComboBoxModel.java
+++ b/modules/au.com.trgtd.tr.view.topics/src/au/com/trgtd/tr/view/topics/TopicsComboBoxModel.java
@@ -39,7 +39,7 @@ import au.com.trgtd.tr.util.Observer;
  *
  * @author Jeremy Moore
  */
-public class TopicsComboBoxModel extends DefaultComboBoxModel implements Observer {
+public class TopicsComboBoxModel extends DefaultComboBoxModel<Topic> implements Observer {
     
     private Manager<Topic> topicManager;
     private List<Topic> topics;
@@ -98,7 +98,7 @@ public class TopicsComboBoxModel extends DefaultComboBoxModel implements Observe
      * Implement ListModel.getElementAt(int index).
      */
     @Override
-    public Object getElementAt(int index) {
+    public Topic getElementAt(int index) {
         return topics.get(index);
     }
     

--- a/modules/au.com.trgtd.tr.view.topics/src/au/com/trgtd/tr/view/topics/TopicsListCellRenderer.java
+++ b/modules/au.com.trgtd.tr.view.topics/src/au/com/trgtd/tr/view/topics/TopicsListCellRenderer.java
@@ -28,7 +28,7 @@ import tr.model.topic.Topic;
  *
  * @author Jeremy Moore
  */
-public class TopicsListCellRenderer extends JLabel implements ListCellRenderer {
+public class TopicsListCellRenderer extends JLabel implements ListCellRenderer<Topic> {
 
 //    public TopicsListCellRenderer() {
 //        setOpaque(true);
@@ -61,26 +61,24 @@ public class TopicsListCellRenderer extends JLabel implements ListCellRenderer {
 //        }
 //        return this;
 //    }
-    private final ListCellRenderer std;
+    private final ListCellRenderer<? super Topic> std;
 
-    public TopicsListCellRenderer(ListCellRenderer std) {
+    public TopicsListCellRenderer(ListCellRenderer<? super Topic> std) {
         if (std == null) {
             throw new NullPointerException("Standard renderer is null.");
         }
         this.std = std;
     }
 
-    public Component getListCellRendererComponent(JList list, Object value,
+    public Component getListCellRendererComponent(JList<? extends Topic> list, Topic topic,
             int index, boolean isSelected, boolean cellHasFocus) {
 
-        Component c = std.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+        Component c = std.getListCellRendererComponent(list, topic, index, isSelected, cellHasFocus);
 
-        if (!isSelected) {
-            if (value instanceof Topic topic) {
-                ((JLabel)c).setText(topic.getName());
-                c.setBackground(topic.getBackground());
-                c.setForeground(topic.getForeground());
-            }
+        if (!isSelected && topic != null) {
+            ((JLabel) c).setText(topic.getName());
+            c.setBackground(topic.getBackground());
+            c.setForeground(topic.getForeground());
         }
         return c;
     }

--- a/modules/au.com.trgtd.tr.view/src/au/com/trgtd/tr/view/ActorsListCellRenderer.java
+++ b/modules/au.com.trgtd.tr.view/src/au/com/trgtd/tr/view/ActorsListCellRenderer.java
@@ -28,7 +28,7 @@ import tr.model.actor.Actor;
  *
  * @author Jeremy Moore
  */
-public class ActorsListCellRenderer extends JLabel implements ListCellRenderer {
+public class ActorsListCellRenderer extends JLabel implements ListCellRenderer<Actor> {
 
 //    public TopicsListCellRenderer() {
 //        setOpaque(true);
@@ -61,28 +61,27 @@ public class ActorsListCellRenderer extends JLabel implements ListCellRenderer {
 //        }
 //        return this;
 //    }
-    private final ListCellRenderer std;
+    private final ListCellRenderer<? super Actor> std;
 
-    public ActorsListCellRenderer(ListCellRenderer std) {
+    public ActorsListCellRenderer(ListCellRenderer<? super Actor> std) {
         if (std == null) {
             throw new NullPointerException("Standard renderer is null.");
         }
         this.std = std;
     }
 
-    public Component getListCellRendererComponent(JList list, Object value,
+    public Component getListCellRendererComponent(JList<? extends Actor> list, Actor actor,
             int index, boolean isSelected, boolean cellHasFocus) {
 
-        JLabel lbl = (JLabel)std.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+        JLabel lbl = (JLabel)std.getListCellRendererComponent(list, actor, index, isSelected, cellHasFocus);
 
 //        if (!isSelected) {
-            if (value instanceof Actor actor) {
+            if (actor != null) {
                 if (actor.isInactive()) {
                     lbl.setText("<HTML><STRIKE>" + actor.getName() + "</STRIKE></HTML>");
                 } else {
                     lbl.setText(actor.getName());
                 }
-
 //                component.setBackground(actor.getBackground());
 //                component.setForeground(actor.getForeground());
             }

--- a/modules/au.com.trgtd.tr.view/src/au/com/trgtd/tr/view/ChangeStatusPanel.java
+++ b/modules/au.com.trgtd.tr.view/src/au/com/trgtd/tr/view/ChangeStatusPanel.java
@@ -189,7 +189,7 @@ public class ChangeStatusPanel extends JPanel {
         }
     }
 
-    private class StatusComboBoxModel extends DefaultComboBoxModel {
+    private class StatusComboBoxModel extends DefaultComboBoxModel<StatusEnum> {
         private List<StatusEnum> states;
         public StatusComboBoxModel() {
             super();
@@ -200,7 +200,7 @@ public class ChangeStatusPanel extends JPanel {
             states.add(StatusEnum.DELEGATED);
         }
         @Override
-        public Object getElementAt(int index) {
+        public StatusEnum getElementAt(int index) {
             return states.get(index);
         }
         @Override
@@ -321,7 +321,7 @@ public class ChangeStatusPanel extends JPanel {
     private JPanel panelAction;
     private JPanel statusPanel;
     // Status
-    private JComboBox statusCombo;
+    private JComboBox<StatusEnum> statusCombo;
     private TRLabel statusLabel;
     // Scheduled
     private DateField scheduledDateField;

--- a/modules/au.com.trgtd.tr.view/src/au/com/trgtd/tr/view/actors/ActorsComboBox.java
+++ b/modules/au.com.trgtd.tr.view/src/au/com/trgtd/tr/view/actors/ActorsComboBox.java
@@ -37,7 +37,7 @@ import tr.model.actor.Actor;
  *
  * @author Jeremy Moore
  */
-public class ActorsComboBox extends TRComboBox implements ActionListener {
+public class ActorsComboBox extends TRComboBox<Actor> implements ActionListener {
 
     public final static String PROP_SELECTED = "selected";
 

--- a/modules/au.com.trgtd.tr.view/src/au/com/trgtd/tr/view/actors/ActorsComboBoxModel.java
+++ b/modules/au.com.trgtd.tr.view/src/au/com/trgtd/tr/view/actors/ActorsComboBoxModel.java
@@ -38,7 +38,7 @@ import tr.model.util.Manager;
  *
  * @author Jeremy Moore
  */
-public final class ActorsComboBoxModel extends DefaultComboBoxModel implements Observer, LookupListener {
+public final class ActorsComboBoxModel extends DefaultComboBoxModel<Actor> implements Observer, LookupListener {
 
     public static final Actor ACTOR_CLR = new Actor(0);
     public static final Actor ACTOR_ADD = new Actor(1);
@@ -127,7 +127,7 @@ public final class ActorsComboBoxModel extends DefaultComboBoxModel implements O
      * @return 
      */
     @Override
-    public Object getElementAt(int index) {
+    public Actor getElementAt(int index) {
         return list.get(index);
     }
 
@@ -140,8 +140,8 @@ public final class ActorsComboBoxModel extends DefaultComboBoxModel implements O
     }
 
     @Override
-    public void addElement(Object anObject) {
-        super.addElement(anObject);
+    public void addElement(Actor anActor) {
+        super.addElement(anActor);
         fireContentsChanged(this, 0, getSize());
     }
 

--- a/modules/au.com.trgtd.tr.view/src/au/com/trgtd/tr/view/actors/ActorsListCellRenderer.java
+++ b/modules/au.com.trgtd.tr.view/src/au/com/trgtd/tr/view/actors/ActorsListCellRenderer.java
@@ -28,7 +28,7 @@ import tr.model.actor.Actor;
  *
  * @author Jeremy Moore
  */
-public class ActorsListCellRenderer extends JLabel implements ListCellRenderer {
+public class ActorsListCellRenderer extends JLabel implements ListCellRenderer<Actor> {
 
     private final ListCellRenderer std;
 
@@ -40,12 +40,12 @@ public class ActorsListCellRenderer extends JLabel implements ListCellRenderer {
     }
 
     @Override
-    public Component getListCellRendererComponent(JList list, Object value,
+    public Component getListCellRendererComponent(JList<? extends Actor> list, Actor actor,
             int index, boolean isSelected, boolean cellHasFocus) {
 
-        JLabel lbl = (JLabel)std.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+        JLabel lbl = (JLabel)std.getListCellRendererComponent(list, actor, index, isSelected, cellHasFocus);
 
-        if (value instanceof Actor actor) {
+        if (actor != null) {
             if (actor.isInactive()) {
                 lbl.setText("<HTML><STRIKE>" + actor.getName() + "</STRIKE></HTML>");
             } else {


### PR DESCRIPTION
This is the forth and last of a series of 4 PRs, each resolving part of the warnings in NetBeans.

This fourth one applies more generics for variable declarations where possible - and applies generics to a few more classes (e.g. `FilterCombo`).

Using generics in classes like `ContextsComboBoxModel`, we can used typed parameters and/or return values, don't need to do the type checks explicitly but leave it to the compiler. One caviat is where some `instanceof` checks implicitly applied a check for null-ness, there we have to replace it with an explicit null check to avoid NPEs. An example would be in `ActorsListCellRenderer.java`.

While kotlin would have baked the null-checks into the language, in Java we can use an annotation based approach to give the compiler some hints if we expect a variable to be nullable or not (see e.g. [here](https://stackoverflow.com/questions/4963300/which-notnull-java-annotation-should-i-use)), and I checked if we already have such an annotation library on the classpath, but could not find one. I think we should add one - but in a separate context. -> #/110

