### PR TITLE
chore: disable modules batik, junit 4 and 5

### DIFF
--- a/nbproject/platform.properties
+++ b/nbproject/platform.properties
@@ -14,7 +14,10 @@ cluster.path=\
     ${nbplatform.active.dir}/harness:\
     ${nbplatform.active.dir}/platform
 
-disabled.modules=
+disabled.modules=\
+    org.netbeans.libs.batik.read,\
+    org.netbeans.libs.junit4,\
+    org.netbeans.libs.junit5,\
     com.googlecode.javaewah.JavaEWAH,\
     com.jcraft.jsch,\
     com.jcraft.jzlib,\


### PR DESCRIPTION
This PR partially repeates what we did in PR #66 (ticket #57), but it sill keeps the cluster `ide` enabled.

To our current knowledge, we need the cluster `ide` for the CI / or currently also to run the tests on our computers locally.

On the downside, the current configuration includes this cluster `ide` also in the installers, with several negative effects:

- the installer size is still far too big
- the cluster `ide` drags some modules into the plugin manager, one of the main reasons why we removed the cluster in PR #66, before we realized we'lre breaking the build for new installations (our own + CI were still passing, as the cluster was still (wrongly) provided by the cache).

Therefore the current PR does not fully solve #57, we still need to get the non-TR related modules out of the plugin manager.

This may at least partially resolve #103. We currently still have a Netbeans Profile next to the ThinkingRock profile in the Options->Keymap section. I presume that is still pulled in by the `ide` module.

Possibly this also helps with #95, at least I do not have the flatlaf panel anymore:
![image](https://user-images.githubusercontent.com/357238/222784598-8a3f3533-3dd1-4949-b047-a566cb9c5134.png)
