### PR TITLE
chore: [#120] just recipes to delete prod/dev caches

### DIFF
--- a/justfile
+++ b/justfile
@@ -141,3 +141,21 @@ verify-ui:
 # Shows some diagnostics used by ant
 diagnostics:
     ant -diagnostics
+
+
+# Clears the cache of the local development version of ThinkingRock
+[linux]
+[macos]
+clear-cache-dev:
+	rm -rI ./build/testuserdir/var/cache/
+
+# Clears the cache of production versions of ThinkingRock
+[linux]
+clear-cache-prod:
+	rm -rI ~/.cache/trgtd/
+
+# Clears the cache of production versions of ThinkingRock
+[macos]
+clear-cache-prod:
+	rm -rI ~/Library/Caches/trgtd/
+

--- a/justfile
+++ b/justfile
@@ -1,9 +1,12 @@
+set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
+
 @_list:
     just --list --unsorted
 
 repodir := `pwd`
 
 netbeans-plat-version := "17"
+win_appdata_dir := env_var('APPDATA')
 
 alias verify-ci := verify-tr
 
@@ -149,6 +152,11 @@ diagnostics:
 clear-cache-dev:
 	rm -rI ./build/testuserdir/var/cache/
 
+# Clears the cache of the local development version of ThinkingRock
+[windows]
+clear-cache-dev:
+	rm -r -fo ./build/testuserdir/var/cache/
+
 # Clears the cache of production versions of ThinkingRock
 [linux]
 clear-cache-prod:
@@ -159,3 +167,7 @@ clear-cache-prod:
 clear-cache-prod:
 	rm -rI ~/Library/Caches/trgtd/
 
+# Clears the cache of production versions of ThinkingRock
+[windows]
+clear-cache-prod:
+	rm -r -fo {{win_appdata_dir}}\..\Local\trgtd\Cache\

--- a/justfile
+++ b/justfile
@@ -6,7 +6,6 @@ set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
 repodir := `pwd`
 
 netbeans-plat-version := "17"
-win_appdata_dir := env_var('APPDATA')
 
 alias verify-ci := verify-tr
 
@@ -170,4 +169,4 @@ clear-cache-prod:
 # Clears the cache of production versions of ThinkingRock
 [windows]
 clear-cache-prod:
-	rm -r -fo {{win_appdata_dir}}\..\Local\trgtd\Cache\
+	rm -r -fo env_var('APPDATA')\..\Local\trgtd\Cache\


### PR DESCRIPTION
Fixes #120 

adds just recipes:

```
    clear-cache-dev      # Clears the cache of the local development version of ThinkingRock
    clear-cache-prod     # Clears the cache of production versions of ThinkingRock
```

Currently there are implementations for linux, Mac and Windows. On Windows we may have up iterate on it once we have deva working on that platform. 

I applied the `-I` flag to the remove command, with the intention to prompt the user for confirmation before starting to delete, but only once. If we'd use the `-i` flag, it would prompt for every nested directory. On windows, we don't prompt. 

~I am not sure if the mac version of `rm` supports this flag. @RadekCap please test and report here if it works.~ [Confirmed]

- [x] Added and validated for Linux
- [x] Added and validated for Mac
- [x] Added and validated for Windows