### PR TITLE
refactor: resolve warnings

### DIFF
--- a/modules/au.com.trgtd.tr.cal/src/au/com/trgtd/tr/cal/view/DayGridPanel.java
+++ b/modules/au.com.trgtd.tr.cal/src/au/com/trgtd/tr/cal/view/DayGridPanel.java
@@ -435,10 +435,8 @@ public class DayGridPanel extends JLayeredPane {
             return eventEnd(events.get(0).getEvent());
         }
 
-        public boolean overlaps(EventGroup thatGroup) {
-            if (null == thatGroup) {
-                return false;
-            }
+        private boolean overlaps(EventGroup thatGroup) {
+            assert(thatGroup != null);
             Date thisBeg = starts();
             Date thisEnd = ends();
             Date thatBeg = thatGroup.starts();

--- a/modules/au.com.trgtd.tr.cal/src/au/com/trgtd/tr/cal/view/DayGridPanel.java
+++ b/modules/au.com.trgtd.tr.cal/src/au/com/trgtd/tr/cal/view/DayGridPanel.java
@@ -444,10 +444,7 @@ public class DayGridPanel extends JLayeredPane {
             if (thatEnd.before(thisBeg)) {
                 return false;
             }
-            if (thatBeg.after(thisEnd)) {
-                return false;
-            }
-            return true;
+            return !thatBeg.after(thisEnd);
         }
 
         private final Comparator<EventPanel> descEndComparator = (EventPanel event1, EventPanel event2) -> {

--- a/modules/au.com.trgtd.tr.cal/src/au/com/trgtd/tr/cal/view/DayGridPanel.java
+++ b/modules/au.com.trgtd.tr.cal/src/au/com/trgtd/tr/cal/view/DayGridPanel.java
@@ -165,7 +165,7 @@ public class DayGridPanel extends JLayeredPane {
         EventGroup lastGroup = null;
         EventPanel lastEvent = null;
         for (EventPanel event : events) {
-            if (lastEvent != null && sameStart(event, lastEvent)) {
+            if (lastEvent != null && sameStart(event, lastEvent) && lastGroup != null) {
                 lastGroup.add(event);
             } else {
                 lastGroup = new EventGroup();
@@ -178,7 +178,7 @@ public class DayGridPanel extends JLayeredPane {
         // set group indentations
         lastGroup = null;
         for (EventGroup thisGroup : groups) {
-            if (thisGroup.overlaps(lastGroup)) {
+            if (lastGroup != null && thisGroup.overlaps(lastGroup)) {
                 lastGroup.incrIndentRight();
                 thisGroup.setIndentLeft(lastGroup.indentLeft() + 1);
             }

--- a/modules/au.com.trgtd.tr.calendar.ical4j.impl/src/au/com/trgtd/tr/calendar/ical4j/impl/ICalendarSynchronizer.java
+++ b/modules/au.com.trgtd.tr.calendar.ical4j.impl/src/au/com/trgtd/tr/calendar/ical4j/impl/ICalendarSynchronizer.java
@@ -209,9 +209,6 @@ public class ICalendarSynchronizer implements CalendarSynchronizer {
                 if (startDate != null) {
                     sb.append("Start: ").append(Constants.DATE_FORMAT_FIXED.format(startDate)).append("\r\n");
                 }
-                if (dueDate != null) {
-                    sb.append("Due: ").append(Constants.DATE_FORMAT_FIXED.format(dueDate)).append("\r\n");
-                }
                 String notes = sb.toString() + getNotes(project);
                 iCalProject.createAllDayEvent(uid, dueDate, descr, notes, null, priority);
             }

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Email.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Email.java
@@ -179,6 +179,7 @@ public class Email extends Thread {
 
                 msgs.add(msg);
                 if (lookForLast) {
+                    @SuppressWarnings("null")
                     String msgUID = pop3folder.getUID(msg);
                     if (msgUID != null && msgUID.equals(lastUID)) {
                         lastUIDIndex = msgs.size() - 1;

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Email.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Email.java
@@ -48,7 +48,7 @@ import static tr.model.util.delegation.DelegationData.Type.RESPONSE;
  *
  * @author Jeremy Moore
  */
-public class Email extends Thread {
+public class Email {
 
     private static final Logger LOG = Logger.getLogger("tr.email");
 

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Email.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Email.java
@@ -52,7 +52,9 @@ public class Email extends Thread {
 
     private static final Logger LOG = Logger.getLogger("tr.email");
 
+    // Suppress default constructor for noninstantiability
     private Email() {
+        throw new AssertionError();
     }
 
     public static void retrieve() {

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Email.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Email.java
@@ -203,7 +203,7 @@ public class Email extends Thread {
                 }
             }
 
-            if (!msgs.isEmpty()) {
+            if (!msgs.isEmpty() && pop3folder != null) {
                 String newLastUID = pop3folder.getUID(msgs.get(msgs.size() - 1));
                 EmailPrefs.setLastMsgUID(newLastUID);
             }

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Email.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Email.java
@@ -248,9 +248,9 @@ public class Email extends Thread {
                 file = new File(attachDir, name + "-" + (n++) + "." + extn);
             }
 
-            FileOutputStream fos = new FileOutputStream(file);
-            fos.write(attach.getContent());
-            fos.close();
+            try (FileOutputStream fos = new FileOutputStream(file)) {
+                fos.write(attach.getContent());
+            }
 
             String url = file.toURL().toExternalForm();
             sbNotes.append("[").append(url).append("|").append(file.getName()).append("]\n");

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
@@ -1112,10 +1112,8 @@ public class Pop3 {
          * Retourne un objet Long reprÈsentant un Message-ID
          */
         public static Long getMessageID() {
-            Long c_id = new Long(0);
             double d = java.lang.Math.random();
-            c_id = new Long((long) (d * Long.MAX_VALUE));
-            return c_id;
+            return (long) (d * Long.MAX_VALUE);
         }
 
         /**

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
@@ -637,7 +637,7 @@ public class Pop3 {
         if (_srcFolder == null || _destFolder == null) {
             return false;
         }
-        Folder targetF = null;
+        Folder targetF;
         Folder sourceF = store.getFolder(_srcFolder);
         sourceF.open(Folder.READ_ONLY);
         if (sourceF.exists() && sourceF.isOpen() && createFolder(_destFolder)) {
@@ -885,7 +885,7 @@ public class Pop3 {
          * @return String        Retourne un String contenant le corps (texte) du mail
          */
         public static String getBody(Message pop_message) throws Exception {
-            String body = null;
+            String body;
             Object content = pop_message.getContent();
             if (content instanceof Multipart mp) {
                 body = getBodyHandleMultipart(mp);
@@ -1045,8 +1045,7 @@ public class Pop3 {
                     xjcharset = MimeUtility.javaCharset("ASCII");
                 }
 
-                InputStreamReader inReader = null;
-
+                InputStreamReader inReader;
                 try {
                     inReader = new InputStreamReader(xis, xjcharset);
                 } catch (UnsupportedEncodingException ex) {

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
@@ -772,15 +772,14 @@ public class Pop3 {
             File file = new File(c_dir + _filename);
             FileOutputStream fos = new FileOutputStream(file);
 
-            BufferedOutputStream bos = new BufferedOutputStream(fos);
-            BufferedInputStream bis = new BufferedInputStream(_input);
-            int aByte;
-            while ((aByte = bis.read()) != -1) {
-                bos.write(aByte);
+            BufferedInputStream bis;
+            try (BufferedOutputStream bos = new BufferedOutputStream(fos)) {
+                bis = new BufferedInputStream(_input);
+                int aByte;
+                while ((aByte = bis.read()) != -1) {
+                    bos.write(aByte);
+                }   bos.flush();
             }
-
-            bos.flush();
-            bos.close();
             bis.close();
 
             return (c_dir + _filename);

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
@@ -60,6 +60,8 @@ import javax.mail.internet.MimeUtility;
 
 import com.sun.mail.imap.IMAPSSLStore;
 import com.sun.mail.pop3.POP3SSLStore;
+import java.io.FileNotFoundException;
+import org.openide.util.Exceptions;
 
 /**
  * Classe permettant de rÈcupÈrer des mails sur un serveur Pop3 ou Imap4 (avec SSL ou non) <br>
@@ -1215,19 +1217,15 @@ public class Pop3 {
         }
 
         private void attach(String c_file) {
-            RandomAccessFile c_raf = null;
-            try {
-                c_raf = new RandomAccessFile(c_file, "rw");
+            try (RandomAccessFile c_raf =new RandomAccessFile(c_file, "rw")) {
                 c_size = (int) c_raf.length();
                 c_b = new byte[((c_size < 80) ? c_size : 80)];
                 c_raf.readFully(c_b);
                 c_header = new String(c_b, 0, c_b.length, "8859_1");
-                c_raf.close();
-            } catch (Throwable t) {
-                try {
-                    c_raf.close();
-                } catch (Exception h) {
-                }
+            } catch (FileNotFoundException ex) {
+                Exceptions.printStackTrace(ex);
+            } catch (IOException ex) {
+                Exceptions.printStackTrace(ex);
             }
         }
 

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
@@ -1081,7 +1081,7 @@ public class Pop3 {
          */
         public static void saveELM(MimeMessage mess, File file_dest) throws MessagingException, IOException {
             String message_id = encodeMessageID(mess.getMessageID());
-            if ("".equals(message_id)) {
+            if (message_id.isEmpty()) {
                 message_id = "" + getMessageID(); // pas de Message-ID ???
             }
             try (PrintWriter out = new PrintWriter(new FileWriter(file_dest.getAbsolutePath() + a_sep + message_id + ".eml"), true)) {
@@ -1090,21 +1090,17 @@ public class Pop3 {
                     Header header = (Header) e.nextElement();
                     out.println(header.getName() + ": " + header.getValue());
                 }
-
                 out.println();
 
                 InputStream in = mess.getInputStream();
                 BufferedReader a_br = new BufferedReader(new InputStreamReader(in, "8859_1"));
-                String a_str = "";
-                String a_strAux = "";
+                StringBuilder a_str = new StringBuilder();
+                String a_strAux;
                 while ((a_strAux = a_br.readLine()) != null) {
-                    a_str += a_strAux + "\n";
+                    a_str.append(a_strAux).append("\n");
                 }
-                out.println(a_str);
-
+                out.println(a_str.toString());
                 out.println();
-
-                // flush & ferme le flux...
                 out.flush();
             }
         }

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
@@ -1295,48 +1295,27 @@ public class Pop3 {
         }
 
         public boolean isWord() {
-            if (c_file.lastIndexOf("doc") != -1) {
-                return true;
-            }
-            return false;
+            return c_file.lastIndexOf("doc") != -1;
         }
 
         public boolean isExcel() {
-            if (c_file.lastIndexOf("xls") != -1) {
-                return true;
-            }
-            return false;
+            return c_file.lastIndexOf("xls") != -1;
         }
 
         public boolean isPPoint() {
-            if (c_file.lastIndexOf("ppt") != -1) {
-                return true;
-            }
-            return false;
+            return c_file.lastIndexOf("ppt") != -1;
         }
 
         public boolean isHtml() {
-            if (c_file.lastIndexOf("htm") != -1 || c_file.lastIndexOf("html") != -1) {
-                return true;
-            }
-            return false;
+            return c_file.lastIndexOf("htm") != -1 || c_file.lastIndexOf("html") != -1;
         }
 
         public boolean isTxt() {
-            if (c_file.lastIndexOf("txt") != -1) {
-                return true;
-            }
-            return false;
+            return c_file.lastIndexOf("txt") != -1;
         }
 
         public boolean isSuffixe(String _ext) {
-            if (_ext == null) {
-                return false;
-            }
-            if (c_file.lastIndexOf(_ext) != -1) {
-                return true;
-            }
-            return false;
+            return _ext != null && c_file.lastIndexOf(_ext) != -1;
         }
 
         private String tohexString(byte abyte0[], int i, int j) {

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
@@ -1084,30 +1084,29 @@ public class Pop3 {
             if ("".equals(message_id)) {
                 message_id = "" + getMessageID(); // pas de Message-ID ???
             }
-            PrintWriter out = new PrintWriter(new FileWriter(file_dest.getAbsolutePath() + a_sep + message_id + ".eml"), true);
+            try (PrintWriter out = new PrintWriter(new FileWriter(file_dest.getAbsolutePath() + a_sep + message_id + ".eml"), true)) {
+                Enumeration e = mess.getAllHeaders();
+                while (e.hasMoreElements()) {
+                    Header header = (Header) e.nextElement();
+                    out.println(header.getName() + ": " + header.getValue());
+                }
 
-            Enumeration e = mess.getAllHeaders();
-            while (e.hasMoreElements()) {
-                Header header = (Header) e.nextElement();
-                out.println(header.getName() + ": " + header.getValue());
+                out.println();
+
+                InputStream in = mess.getInputStream();
+                BufferedReader a_br = new BufferedReader(new InputStreamReader(in, "8859_1"));
+                String a_str = "";
+                String a_strAux = "";
+                while ((a_strAux = a_br.readLine()) != null) {
+                    a_str += a_strAux + "\n";
+                }
+                out.println(a_str);
+
+                out.println();
+
+                // flush & ferme le flux...
+                out.flush();
             }
-
-            out.println();
-
-            InputStream in = mess.getInputStream();
-            BufferedReader a_br = new BufferedReader(new InputStreamReader(in, "8859_1"));
-            String a_str = "";
-            String a_strAux = "";
-            while ((a_strAux = a_br.readLine()) != null) {
-                a_str += a_strAux + "\n";
-            }
-            out.println(a_str);
-
-            out.println();
-
-            // flush & ferme le flux...
-            out.flush();
-            out.close();
         }
 
         /**

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
@@ -395,29 +395,26 @@ public class Pop3 {
 
         // only for Microsoft Exchange...
         //props.put("mail.pop3.forgettopheaders", "true");
-
         // Setup mail server port
-        if (c_protocol.equals(POP)) {
-            props.put("mail.pop3.port", "" + c_port);
-            if (TLS) {
-                props.put("mail.pop3.starttls.enable", "true");
-            }
-            if (c_timeout != 0) {
-                props.put("mail.pop3.connectiontimeout", "" + c_timeout);
-                props.put("mail.pop3.timeout", "" + c_timeout);
-            }
-        } else if (c_protocol.equals(IMAP)) {
-            props.put("mail.imap.port", "" + c_port);
-
-            if (TLS) {
-                props.put("mail.imap.starttls.enable", "true");
-            }
-            if (c_timeout != 0) {
-                props.put("mail.imap.connectiontimeout", "" + c_timeout);
-                props.put("mail.imap.timeout", "" + c_timeout);
-            }
-        } else {
-            throw new MessagingException("Unknow Protocol : " + c_protocol);
+        switch (c_protocol) {
+            case POP:
+                props.put("mail.pop3.port", "" + c_port);
+                if (TLS) {
+                    props.put("mail.pop3.starttls.enable", "true");
+                }   if (c_timeout != 0) {
+                    props.put("mail.pop3.connectiontimeout", "" + c_timeout);
+                    props.put("mail.pop3.timeout", "" + c_timeout);
+                }   break;
+            case IMAP:
+                props.put("mail.imap.port", "" + c_port);
+                if (TLS) {
+                    props.put("mail.imap.starttls.enable", "true");
+                }   if (c_timeout != 0) {
+                    props.put("mail.imap.connectiontimeout", "" + c_timeout);
+                    props.put("mail.imap.timeout", "" + c_timeout);
+                }   break;
+            default:
+                throw new MessagingException("Unknow Protocol : " + c_protocol);
         }
 
         // mode debug

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
@@ -1139,10 +1139,7 @@ public class Pop3 {
          * @throws IOException
          */
         public static MimeMessage getMimeMessage(File f_eml) throws MessagingException, IOException {
-            MimeMessage message = null;
-            InputStream source = new FileInputStream(f_eml);
-            message = new MimeMessage(null, source);
-            return message;
+            return new MimeMessage(null, new FileInputStream(f_eml));
         }
 
         /**

--- a/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
+++ b/modules/au.com.trgtd.tr.email/src/au/com/trgtd/tr/email/Pop3.java
@@ -1048,9 +1048,7 @@ public class Pop3 {
                 InputStreamReader inReader;
                 try {
                     inReader = new InputStreamReader(xis, xjcharset);
-                } catch (UnsupportedEncodingException ex) {
-                    inReader = null;
-                } catch (IllegalArgumentException ex) {
+                } catch (UnsupportedEncodingException | IllegalArgumentException ex) {
                     inReader = null;
                 }
 
@@ -1574,7 +1572,7 @@ public class Pop3 {
             }
 
             System.out.println("End Job --- Pop3");
-        } catch (Exception e) {
+        } catch (MessagingException e) {
             System.out.println(e);
             System.out.println("Pile : ");
             e.printStackTrace();


### PR DESCRIPTION
Based on netbeans inspections and lead by dereferencing NPEs, there is a cumulation of small fixes/refactorings of warnings on four classes:

- Pop3
- Email
- ICalendarSynchronizer
- DayGridPanel

Most refactorings were mechanical.

In the `DayGridPanel`, I changed a method to be private and moved the null check outside to make it easier to spot that the nullability warning was actually a false-positive.

`Email` most likely started out as a class extending Thread but later seemed to have evolved to a pure utility class with only static methods. Extending `Thread` is not needed, so I removed this obsolete inheritance.

I created a separate PR #126 to format/organize imports and remove commented out code - to keep the PRs a bit smaller