### PR TITLE
chore: Ignore module sql.editor

### DIFF
--- a/nbproject/platform.properties
+++ b/nbproject/platform.properties
@@ -48,6 +48,7 @@ disabled.modules=\
     org.netbeans.modules.db.kit,\
     org.netbeans.modules.db.metadata.model,\
     org.netbeans.modules.db.mysql,\
+    org.netbeans.modules.db.sql.editor,\
     org.netbeans.modules.db.sql.visualeditor,\
     org.netbeans.modules.dbapi,\
     org.netbeans.modules.derby,\


### PR DESCRIPTION
Uplon first start, the launcher complains about an issue installing module SQL.editor.

<details><summary>Error message</summary>
Warning - could not install some modules: SQL Editor - The module named org.netbeans.modules.editor/3 was needed and not found. SQL Editor - The module named org.netbeans.modules.csl.types/1 was needed and not found. SQL Editor - The module named org.netbeans.modules.editor.fold/1 was needed and not found. SQL Editor - The module named org.netbeans.modules.db/1 was needed and not found. SQL Editor - The module named org.netbeans.modules.db.metadata.model/0-1 was needed and not found. SQL Editor - The module named org.netbeans.modules.editor.bracesmatching/0-1 was needed and not found. SQL Editor - The module named org.netbeans.modules.dbapi was needed and not found. SQL Editor - The module named org.netbeans.modules.csl.api/2 was needed and not found. SQL Editor - The module named org.netbeans.modules.editor.completion/1 was needed and not found. SQL Editor - The module named org.netbeans.modules.editor.lib2/1 was needed and not found. SQL Editor - The module named org.netbeans.modules.editor.document was needed and not found. SQL Editor - The module named org.netbeans.modules.db.core was needed and not found. SQL Editor - The module named org.netbeans.modules.lexer/2 was needed and not found. SQL Editor - The module named org.netbeans.modules.editor.lib/3 was needed and not found. SQL Editor - The module named org.netbeans.modules.projectapi/1 was needed and not found.
</details>

TR can still be launched (click "disable modules and continue"). 
However, the netbeans module is not relevant for ThinkingRock and should not be loaded. This PR disables it.