### PR TITLE
chore: just recipe to run TR application directly from sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ This issue will be solved in #33.
 - [Apache Ant](https://ant.apache.org/manual/install.html) is installed
 - Optional: [just](https://github.com/casey/just) is installed
 
-#### Run
+#### Run TR directly from sources
+- with 'just' installed, simply run `just run`
+
+### Build artefacts and run
 - open a terminal window (Xterm, Konsole, Dos prompt, PowerShell...) and navigate to the root of the git clone tr-pc
 - run `ant build-zip -Dnbplatform.default.netbeans.dest.dir=${path_to_repo}/netbeans-plat/20/ide` (replace `${path_to_repo}` with the absolte path to the checked out `tr-pc` repository)
 - you will find a zip file *trgtd.zip* inside the folder *dist*.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This issue will be solved in #33.
 - Optional: [just](https://github.com/casey/just) is installed
 
 #### Run TR directly from sources
-- with 'just' installed, simply run `just run`
+- with 'just' installed, simply run `just run` (after having run `just build` at least once before)
 
 ### Build artefacts and run
 - open a terminal window (Xterm, Konsole, Dos prompt, PowerShell...) and navigate to the root of the git clone tr-pc

--- a/justfile
+++ b/justfile
@@ -6,6 +6,7 @@ set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
 repodir := `pwd`
 
 netbeans-plat-version := "20"
+java-version := "17"
 
 alias verify-ci := verify-tr
 
@@ -174,7 +175,7 @@ clear-cache-prod:
 # Starts the ThinkingRock application from sources
 run:
 	ant -f ./modules/au.com.trgtd.tr.calendar \
-	    -Dant.build.javac.target=17 \
-	    -Dant.build.javac.source=17 \
+	    -Dant.build.javac.target={{ java-version }} \
+	    -Dant.build.javac.source={{ java-version }} \
 	    -Dcontinue.after.failing.tests=true \
 	    run

--- a/justfile
+++ b/justfile
@@ -170,3 +170,11 @@ clear-cache-prod:
 [windows]
 clear-cache-prod:
 	rm -r -fo env_var('APPDATA')\..\Local\trgtd\Cache\
+
+# Starts the ThinkingRock application from sources
+run:
+	ant -f ./modules/au.com.trgtd.tr.calendar \
+	    -Dant.build.javac.target=17 \
+	    -Dant.build.javac.source=17 \
+	    -Dcontinue.after.failing.tests=true \
+	    run

--- a/justfile
+++ b/justfile
@@ -6,6 +6,7 @@ set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
 repodir := `pwd`
 
 netbeans-plat-version := "21"
+java-version := "17"
 
 alias verify-ci := verify-tr
 


### PR DESCRIPTION
- adds just recipe to run the application from sources (`just run`).
- updates the README accordingly

Easier to test after merge of #138.